### PR TITLE
Add FOSCKeditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # vektor-backend
 
-(Currently in progress)
+(Work in progress)
 
 ## Set up development environment
 ### Requirements:
 - [PHP](http://php.net/downloads.php) version 7.4
 - [Node](https://nodejs.org/en/) version 14
-- [Git](https://git-scm.com/)
+### Recommended:
+- [Symfony CLI](https://symfony.com/download)
+
+### PHP dependencies
+- php7.4-zip
+- php7.4-gd
+- php7.4-sqlite3
+
 
 ### Setup:
-
-#### Clone files:
-`git clone https://github.com/vektorprogrammet/vektor-backend.git`
 
 ##### UNIX:
 `npm run setup`
@@ -22,7 +26,7 @@
 `npm start`
 
 ##### Alternatively
-you can also run the app using symfony's own local web server with `npm run start:symfony`
+`symfony server:start` (requires Symfony CLI)
 
 #### Build static files
 When adding new images or other non-code files, you can run:

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.0",
         "doctrine/orm": "^2.8",
         "excelwebzone/recaptcha-bundle": "^1.5",
+        "friendsofsymfony/ckeditor-bundle": "^2.3",
         "friendsofsymfony/rest-bundle": "^3.0",
         "liip/imagine-bundle": "^2.5",
         "phpdocumentor/reflection-docblock": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7384fcc63db34ed1bf0491ad8aef38ec",
+    "content-hash": "100820122fd005528dfedac01638c71a",
     "packages": [
         {
             "name": "brick/math",
@@ -1689,6 +1689,87 @@
                 }
             ],
             "time": "2021-01-14T21:52:44+00:00"
+        },
+        {
+            "name": "friendsofsymfony/ckeditor-bundle",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfSymfony/FOSCKEditorBundle.git",
+                "reference": "282c79b0d3eda68855ea4c8732ab8d249cd5fbd0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSCKEditorBundle/zipball/282c79b0d3eda68855ea4c8732ab8d249cd5fbd0",
+                "reference": "282c79b0d3eda68855ea4c8732ab8d249cd5fbd0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": "^7.1|^8.0",
+                "symfony/asset": "^4.4 || ^5.0",
+                "symfony/config": "^4.4 || ^5.0",
+                "symfony/dependency-injection": "^4.4 || ^5.0",
+                "symfony/expression-language": "^4.4 || ^5.0",
+                "symfony/form": "^4.4 || ^5.0",
+                "symfony/framework-bundle": "^4.4 || ^5.0",
+                "symfony/http-foundation": "^4.4 || ^5.0",
+                "symfony/http-kernel": "^4.4 || ^5.0",
+                "symfony/options-resolver": "^4.4 || ^5.0",
+                "symfony/property-access": "^4.4 || ^5.0",
+                "symfony/routing": "^4.4 || ^5.0",
+                "symfony/twig-bundle": "^4.4 || ^5.0",
+                "twig/twig": "^2.4 || ^3.0"
+            },
+            "conflict": {
+                "sebastian/environment": "<1.3.4",
+                "sebastian/exporter": "<2.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.0",
+                "symfony/console": "^4.4 || ^5.0",
+                "symfony/phpunit-bridge": "^4.4 || ^5.0",
+                "symfony/yaml": "^4.4 || ^5.0"
+            },
+            "suggest": {
+                "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FOS\\CKEditorBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "FriendsOfSymfony Community",
+                    "homepage": "https://github.com/FriendsOfSymfony/FOSCKEditorBundle/graphs/contributors"
+                }
+            ],
+            "description": "Provides a CKEditor integration for your Symfony project.",
+            "keywords": [
+                "CKEditor"
+            ],
+            "support": {
+                "issues": "https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues",
+                "source": "https://github.com/FriendsOfSymfony/FOSCKEditorBundle/tree/2.3.0"
+            },
+            "time": "2020-12-26T14:29:00+00:00"
         },
         {
             "name": "friendsofsymfony/rest-bundle",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -17,4 +17,5 @@ return [
     FOS\RestBundle\FOSRestBundle::class => ['all' => true],
     Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     EWZ\Bundle\RecaptchaBundle\EWZRecaptchaBundle::class => ['all' => true],
+    FOS\CKEditorBundle\FOSCKEditorBundle::class => ['all' => true],
 ];

--- a/config/packages/fos_ckeditor.yaml
+++ b/config/packages/fos_ckeditor.yaml
@@ -1,0 +1,5 @@
+# Read the documentation: https://symfony.com/doc/current/bundles/FOSCKEditorBundle/index.html
+
+twig:
+    form_themes:
+        - '@FOSCKEditor/Form/ckeditor_widget.html.twig'

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "scripts": {
     "start": "concurrently --kill-others \"php -S localhost:8000 -t public\" \"npm run watch\"",
-    "start:symfony": "symfony server:start",
     "setup": "php ./composer.phar install --no-scripts && npm install && npm run build:dev && mkdir -p ./var/data && touch ./var/data/dev.db  && php bin/console doctrine:schema:drop --force --env=dev && php bin/console doctrine:schema:create --env=dev && php bin/console doctrine:schema:update --force --env=dev && php bin/console doctrine:fixtures:load --env=dev -n && php bin/console doctrine:migrations:sync-metadata-storage --env=dev -n",
     "watch": "gulp",
     "build:dev": "gulp build:dev",

--- a/src/Form/Type/ArticleType.php
+++ b/src/Form/Type/ArticleType.php
@@ -2,7 +2,7 @@
 
 namespace App\Form\Type;
 
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;

--- a/src/Form/Type/ChangeLogType.php
+++ b/src/Form/Type/ChangeLogType.php
@@ -2,7 +2,7 @@
 
 namespace App\Form\Type;
 
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/src/Form/Type/CreateExecutiveBoardType.php
+++ b/src/Form/Type/CreateExecutiveBoardType.php
@@ -2,7 +2,7 @@
 
 namespace App\Form\Type;
 
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/src/Form/Type/CreateTeamType.php
+++ b/src/Form/Type/CreateTeamType.php
@@ -2,7 +2,7 @@
 
 namespace App\Form\Type;
 
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;

--- a/src/Form/Type/SurveyNotifierType.php
+++ b/src/Form/Type/SurveyNotifierType.php
@@ -5,7 +5,7 @@ namespace App\Form\Type;
 use App\Entity\Survey;
 use App\Entity\SurveyNotificationCollection;
 use App\Entity\UserGroup;
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;

--- a/src/Form/Type/SurveyType.php
+++ b/src/Form/Type/SurveyType.php
@@ -4,7 +4,7 @@ namespace App\Form\Type;
 
 use App\Repository\SemesterRepository;
 use App\Entity\Survey;
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;

--- a/symfony.lock
+++ b/symfony.lock
@@ -121,6 +121,18 @@
     "friendsofphp/proxy-manager-lts": {
         "version": "v1.0.3"
     },
+    "friendsofsymfony/ckeditor-bundle": {
+        "version": "2.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "master",
+            "version": "2.0",
+            "ref": "8eb1cd0962ded6a6d6e1e5a9b6d3e888f9f94ff6"
+        },
+        "files": [
+            "config/packages/fos_ckeditor.yaml"
+        ]
+    },
     "friendsofsymfony/rest-bundle": {
         "version": "2.2",
         "recipe": {


### PR DESCRIPTION
IvoryCKEditorBundle has been abandoned. Luckily for us, FOS (friends of symfony) has taken over the bundle, and made the migration very quick and easy.

**PR:**
- Adds FOSCKEditorBundle
- Updates references to CKEditor, so that the new one is referenced
- Adds a .gitkeep file to preserve the db directory (without it, running `php bin/console doctrine:database:create` would fail, and you would first have to create the `/data` directory first).
- Remove redundant npm script for symfony (just use `symfony server:start`)