### PR TITLE
Update browser-list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,9 +2137,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001199",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
-      "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
       "dev": true
     },
     "caseless": {
@@ -7146,6 +7146,11 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true,
       "optional": true
+    },
+    "perfect-scrollbar": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.2.tgz",
+      "integrity": "sha512-McHAinFkyzKbBZrFtb4MT2mxkehp15KvOX/UrjB8C5EZZXHTHgyETo5IGFYtHRTI2Pb2bsV0OE0YnkjT9Cw3aw=="
     },
     "performance-now": {
       "version": "2.1.0",


### PR DESCRIPTION
From [github.com/browserlist](https://github.com/browserslist/browserslist#browsers-data-updating)


```
You need to do it regularly for two reasons:

- To use the latest browser’s versions and statistics in queries like last 2 versions or >1%. For example, if you created your project 2 years ago and did not update your dependencies, last 1 version will return 2 year old browsers. 

- caniuse-lite deduplication: to synchronize version in different tools.

```