### PR TITLE
[VB-47] Fix forms datetime format error

### DIFF
--- a/src/Form/Type/ChangeLogType.php
+++ b/src/Form/Type/ChangeLogType.php
@@ -37,7 +37,7 @@ class ChangeLogType extends AbstractType
             ],
             'required' => true,
             'auto_initialize' => false,
-
+            'html5' => false,
             ))
         ->add('description', CKEditorType::class, array(
         'required' => false,
@@ -48,7 +48,6 @@ class ChangeLogType extends AbstractType
         'label' => 'Lang beskrivelse (valgfritt)',
         'attr' => array('class' => 'hide'),
             ))
-
         ->add('save', SubmitType::class, array(
             'label' => 'Lagre',
             ));

--- a/src/Form/Type/CreateAdmissionPeriodType.php
+++ b/src/Form/Type/CreateAdmissionPeriodType.php
@@ -33,12 +33,14 @@ class CreateAdmissionPeriodType extends AbstractType
             ->add('startDate', DateTimeType::class, array(
                 'label' => 'Opptak starttidspunkt',
                 'widget' => 'single_text',
-                'format' => 'dd.MM.yyyy HH:mm',
+                'format' => 'dd.MM.yyyy HH:mm', 
+                'html5' => false,
             ))
             ->add('endDate', DateTimeType::class, array(
                 'label' => 'Opptak sluttidspunkt',
                 'widget' => 'single_text',
                 'format' => 'dd.MM.yyyy HH:mm',
+                'html5' => false,
             ))
             ->add('save', SubmitType::class, array(
                 'label' => 'Opprett',

--- a/src/Form/Type/CreateTeamType.php
+++ b/src/Form/Type/CreateTeamType.php
@@ -39,6 +39,7 @@ class CreateTeamType extends AbstractType
                 'format' => 'dd.MM.yyyy HH:mm',
                 'widget' => 'single_text',
                 'required' => false,
+                'html5' => false,
             ))
             ->add('active', CheckboxType::class, array(
                 'label' => 'Aktivt team',

--- a/src/Form/Type/EditAdmissionPeriodType.php
+++ b/src/Form/Type/EditAdmissionPeriodType.php
@@ -16,6 +16,7 @@ class EditAdmissionPeriodType extends AbstractType
                 'label' => 'Opptak starttidspunkt',
                 'format' => 'dd.MM.yyyy HH:mm',
                 'widget' => 'single_text',
+                'html5' => false,
                 'attr' => array(
                     'placeholder' => 'Klikk for å velge tidspunkt',
                 ),
@@ -24,6 +25,7 @@ class EditAdmissionPeriodType extends AbstractType
                 'label' => 'Opptak sluttidspunkt',
                 'format' => 'dd.MM.yyyy HH:mm',
                 'widget' => 'single_text',
+                'html5' => false,
                 'attr' => array(
                     'placeholder' => 'Klikk for å velge tidspunkt',
                 ),

--- a/src/Form/Type/InfoMeetingType.php
+++ b/src/Form/Type/InfoMeetingType.php
@@ -22,6 +22,7 @@ class InfoMeetingType extends AbstractType
                 'label' => 'Dato og klokkeslett',
                 'format' => 'dd.MM.yyyy HH:mm',
                 'widget' => 'single_text',
+                'html5' => false,
                 'attr' => [
                     'placeholder' => 'Klikk for å velge tidspunkt'
                 ]

--- a/src/Form/Type/ScheduleInterviewType.php
+++ b/src/Form/Type/ScheduleInterviewType.php
@@ -26,6 +26,7 @@ class ScheduleInterviewType extends AbstractType
                 'widget' => 'single_text',
                 'format' => 'dd.MM.yyyy HH:mm',
                 'label' => 'Tidspunkt',
+                'html5' => false,
                 'attr' => array('placeholder' => 'Klikk for å velge tidspunkt'),
             ))
 

--- a/src/Form/Type/SocialEventType.php
+++ b/src/Form/Type/SocialEventType.php
@@ -46,6 +46,7 @@ class SocialEventType extends AbstractType
                 'widget' => 'single_text',
                 'format' => 'dd.MM.yyyy HH:mm',
                 'label' => 'Starttid for arrangement',
+                'html5' => false,
                 'attr' => array(
                     'placeholder' => 'Klikk for å velge tidspunkt',
                     'autocomplete' => 'off'
@@ -56,6 +57,7 @@ class SocialEventType extends AbstractType
                 'widget' => 'single_text',
                 'format' => 'dd.MM.yyyy HH:mm',
                 'label' => 'Sluttid for arrangement',
+                'html5' => false,
                 'attr' => array(
                     'placeholder' => 'Klikk for å velge tidspunkt',
                     'autocomplete' => 'off'

--- a/src/Form/Type/SurveyNotifierType.php
+++ b/src/Form/Type/SurveyNotifierType.php
@@ -33,6 +33,7 @@ class SurveyNotifierType extends AbstractType
                 'label' => "Varsel skal sendes fra (merk: vil bare tillate å sende fra gitt dato, vil ikke skje automatisk)",
                 'format' => 'dd.MM.yyyy HH:mm',
                 'widget' => 'single_text',
+                'html5' => false,
                 'disabled' => !$this->canEdit
             ])
 


### PR DESCRIPTION
The html5 option is enabled by default in Symfony 5. This means that the date is of the HTML5 type (date, time or datetime-local), which is wrong since we use the type datetime with a custom text format. Fix: disable html5 option 
