### PR TITLE
[VB-39] Remove duplicated folder variable

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -93,7 +93,6 @@ services:
             $logoFolder: 'images/Logo images'
             $signatureFolder: './signatures'
             $receiptFolder: 'images/receipts'
-            $sponsorFolder: 'images/Logo images'
             $articleFolder: 'images/article_images'
             $profilePhotoFolder: 'images/Profile photos'
 

--- a/src/Service/FileUploader.php
+++ b/src/Service/FileUploader.php
@@ -15,7 +15,6 @@ class FileUploader
     private $receiptFolder;
     private $profilePhotoFolder;
     private $articleFolder;
-    private $sponsorFolder;
 
     /**
      * FileUploader constructor.
@@ -25,16 +24,14 @@ class FileUploader
      * @param string $receiptFolder
      * @param string $profilePhotoFolder
      * @param string $articleFolder
-     * @param string $sponsorFolder
      */
-    public function __construct(string $signatureFolder, string $logoFolder, string $receiptFolder, string $profilePhotoFolder, string $articleFolder, string $sponsorFolder)
+    public function __construct(string $signatureFolder, string $logoFolder, string $receiptFolder, string $profilePhotoFolder, string $articleFolder)
     {
         $this->signatureFolder = $signatureFolder;
         $this->logoFolder = $logoFolder;
         $this->receiptFolder = $receiptFolder;
         $this->profilePhotoFolder = $profilePhotoFolder;
         $this->articleFolder = $articleFolder;
-        $this->sponsorFolder = $sponsorFolder;
     }
 
     /**
@@ -46,7 +43,7 @@ class FileUploader
     {
         $file = $this->getFileFromRequest($request);
 
-        return $this->uploadFile($file, $this->sponsorFolder);
+        return $this->uploadFile($file, $this->logoFolder);
     }
 
     /**
@@ -61,17 +58,6 @@ class FileUploader
         return $this->uploadFile($file, $this->signatureFolder);
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return string
-     */
-    public function uploadLogo(Request $request)
-    {
-        $file = $this->getFileFromRequest($request);
-
-        return $this->uploadFile($file, $this->logoFolder);
-    }
 
     /**
      * @param Request $request
@@ -167,7 +153,7 @@ class FileUploader
 
         $fileName = $this->getFileNameFromPath($path);
 
-        $this->deleteFile("$this->sponsorFolder/$fileName");
+        $this->deleteFile("$this->logoFolder/$fileName");
     }
 
     public function deleteSignature(string $path)


### PR DESCRIPTION
There are two variables, both for the folder name "Logo images".
PR removes duplicate.

From config file (duplicates marked with arrows):
### FileUploader
    App\Service\FileUploader:
        arguments:
            ----->$logoFolder: 'images/Logo images'
            $signatureFolder: './signatures'
            $receiptFolder: 'images/receipts'
            ----->$sponsorFolder: 'images/Logo images'
            $articleFolder: 'images/article_images'
            $profilePhotoFolder: 'images/Profile photos'


PR adds a new function ```getAndVerifyFile```, which allows you to specify which filetypes to accept.