### PR TITLE
VB-142 fix: Add string as return type on getBlockPrefix

### DIFF
--- a/src/Form/Type/AdmissionSubscriberType.php
+++ b/src/Form/Type/AdmissionSubscriberType.php
@@ -43,7 +43,7 @@ class AdmissionSubscriberType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'app_bundle_admission_subscriber_type';
     }

--- a/src/Form/Type/ApplicationExistingUserType.php
+++ b/src/Form/Type/ApplicationExistingUserType.php
@@ -30,7 +30,7 @@ class ApplicationExistingUserType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'application';
     }

--- a/src/Form/Type/ApplicationInterviewType.php
+++ b/src/Form/Type/ApplicationInterviewType.php
@@ -57,7 +57,7 @@ class ApplicationInterviewType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'application';
     }

--- a/src/Form/Type/ApplicationPracticalType.php
+++ b/src/Form/Type/ApplicationPracticalType.php
@@ -93,7 +93,7 @@ class ApplicationPracticalType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'application';
     }

--- a/src/Form/Type/ApplicationType.php
+++ b/src/Form/Type/ApplicationType.php
@@ -40,7 +40,7 @@ class ApplicationType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'application'; // This must be unique
     }

--- a/src/Form/Type/AssignInterviewType.php
+++ b/src/Form/Type/AssignInterviewType.php
@@ -23,7 +23,7 @@ class AssignInterviewType extends AbstractType
     }
 
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'application';
     }

--- a/src/Form/Type/CancelInterviewConfirmationType.php
+++ b/src/Form/Type/CancelInterviewConfirmationType.php
@@ -18,7 +18,7 @@ class CancelInterviewConfirmationType extends AbstractType
             ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'CancelInterviewConfirmation';
     }

--- a/src/Form/Type/CreateAssistantHistoryType.php
+++ b/src/Form/Type/CreateAssistantHistoryType.php
@@ -83,7 +83,7 @@ class CreateAssistantHistoryType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createAssistantHistory';
     }

--- a/src/Form/Type/CreateDepartmentType.php
+++ b/src/Form/Type/CreateDepartmentType.php
@@ -59,7 +59,7 @@ class CreateDepartmentType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createDepartment';
     }

--- a/src/Form/Type/CreateExecutiveBoardMembershipType.php
+++ b/src/Form/Type/CreateExecutiveBoardMembershipType.php
@@ -62,7 +62,7 @@ class CreateExecutiveBoardMembershipType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createExecutiveBoardMembership';
     }

--- a/src/Form/Type/CreateExecutiveBoardType.php
+++ b/src/Form/Type/CreateExecutiveBoardType.php
@@ -47,7 +47,7 @@ class CreateExecutiveBoardType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createExecutiveBoard';
     }

--- a/src/Form/Type/CreateInterviewType.php
+++ b/src/Form/Type/CreateInterviewType.php
@@ -47,7 +47,7 @@ class CreateInterviewType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interview';
     }

--- a/src/Form/Type/CreatePositionType.php
+++ b/src/Form/Type/CreatePositionType.php
@@ -26,7 +26,7 @@ class CreatePositionType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createPosition';
     }

--- a/src/Form/Type/CreateSchoolType.php
+++ b/src/Form/Type/CreateSchoolType.php
@@ -56,7 +56,7 @@ class CreateSchoolType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createSchool';
     }

--- a/src/Form/Type/CreateSemesterType.php
+++ b/src/Form/Type/CreateSemesterType.php
@@ -43,7 +43,7 @@ class CreateSemesterType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createSemester';
     }

--- a/src/Form/Type/CreateTeamMembershipType.php
+++ b/src/Form/Type/CreateTeamMembershipType.php
@@ -79,7 +79,7 @@ class CreateTeamMembershipType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createTeamMembership';
     }

--- a/src/Form/Type/CreateTeamType.php
+++ b/src/Form/Type/CreateTeamType.php
@@ -63,7 +63,7 @@ class CreateTeamType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createTeam';
     }

--- a/src/Form/Type/CreateUserOnApplicationType.php
+++ b/src/Form/Type/CreateUserOnApplicationType.php
@@ -60,7 +60,7 @@ class CreateUserOnApplicationType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createUser';
     }

--- a/src/Form/Type/CreateUserType.php
+++ b/src/Form/Type/CreateUserType.php
@@ -59,7 +59,7 @@ class CreateUserType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createUser';
     }

--- a/src/Form/Type/CropImageType.php
+++ b/src/Form/Type/CropImageType.php
@@ -25,7 +25,7 @@ class CropImageType extends AbstractType
             ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'crop';
     }

--- a/src/Form/Type/DaysType.php
+++ b/src/Form/Type/DaysType.php
@@ -101,7 +101,7 @@ class DaysType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'application';
     }

--- a/src/Form/Type/EditAdmissionPeriodType.php
+++ b/src/Form/Type/EditAdmissionPeriodType.php
@@ -43,7 +43,7 @@ class EditAdmissionPeriodType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'editAdmissionPeriod';
     }

--- a/src/Form/Type/EditUserPasswordType.php
+++ b/src/Form/Type/EditUserPasswordType.php
@@ -40,7 +40,7 @@ class EditUserPasswordType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'editUserPassword';
     }

--- a/src/Form/Type/EditUserType.php
+++ b/src/Form/Type/EditUserType.php
@@ -59,7 +59,7 @@ class EditUserType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'editUser';
     }

--- a/src/Form/Type/FieldOfStudyType.php
+++ b/src/Form/Type/FieldOfStudyType.php
@@ -33,7 +33,7 @@ class FieldOfStudyType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'app_bundle_field_of_study_type';
     }

--- a/src/Form/Type/InterviewAnswerType.php
+++ b/src/Form/Type/InterviewAnswerType.php
@@ -89,7 +89,7 @@ class InterviewAnswerType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interviewAnswer';
     }

--- a/src/Form/Type/InterviewNewTimeType.php
+++ b/src/Form/Type/InterviewNewTimeType.php
@@ -26,7 +26,7 @@ class InterviewNewTimeType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'InterviewNewTime';
     }

--- a/src/Form/Type/InterviewQuestionAlternativeType.php
+++ b/src/Form/Type/InterviewQuestionAlternativeType.php
@@ -24,7 +24,7 @@ class InterviewQuestionAlternativeType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interviewQuestionAlternative';
     }

--- a/src/Form/Type/InterviewQuestionType.php
+++ b/src/Form/Type/InterviewQuestionType.php
@@ -50,7 +50,7 @@ class InterviewQuestionType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interviewQuestion';
     }

--- a/src/Form/Type/InterviewSchemaType.php
+++ b/src/Form/Type/InterviewSchemaType.php
@@ -37,7 +37,7 @@ class InterviewSchemaType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interviewSchema';
     }

--- a/src/Form/Type/InterviewScoreType.php
+++ b/src/Form/Type/InterviewScoreType.php
@@ -50,7 +50,7 @@ class InterviewScoreType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interviewScore';
     }

--- a/src/Form/Type/InterviewType.php
+++ b/src/Form/Type/InterviewType.php
@@ -23,7 +23,7 @@ class InterviewType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'interview';
     }

--- a/src/Form/Type/ModifySubstituteType.php
+++ b/src/Form/Type/ModifySubstituteType.php
@@ -51,7 +51,7 @@ class ModifySubstituteType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'modifySubstitute';
     }

--- a/src/Form/Type/NewPasswordType.php
+++ b/src/Form/Type/NewPasswordType.php
@@ -36,7 +36,7 @@ class NewPasswordType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'newPassword'; // This must be unique
     }

--- a/src/Form/Type/NewUserType.php
+++ b/src/Form/Type/NewUserType.php
@@ -43,7 +43,7 @@ class NewUserType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'createNewUser';
     }

--- a/src/Form/Type/PasswordResetType.php
+++ b/src/Form/Type/PasswordResetType.php
@@ -18,7 +18,7 @@ class PasswordResetType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'passwordReset'; // This must be unique
     }

--- a/src/Form/Type/ScheduleInterviewType.php
+++ b/src/Form/Type/ScheduleInterviewType.php
@@ -54,7 +54,7 @@ class ScheduleInterviewType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'scheduleInterview';
     }

--- a/src/Form/Type/SchoolCapacityEditType.php
+++ b/src/Form/Type/SchoolCapacityEditType.php
@@ -27,7 +27,7 @@ class SchoolCapacityEditType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'schoolCapacity';
     }

--- a/src/Form/Type/SchoolCapacityType.php
+++ b/src/Form/Type/SchoolCapacityType.php
@@ -40,7 +40,7 @@ class SchoolCapacityType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'schoolCapacity';
     }

--- a/src/Form/Type/SponsorType.php
+++ b/src/Form/Type/SponsorType.php
@@ -38,7 +38,7 @@ class SponsorType extends AbstractType
             ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sponsor';
     }

--- a/src/Form/Type/SupportTicketType.php
+++ b/src/Form/Type/SupportTicketType.php
@@ -78,7 +78,7 @@ class SupportTicketType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'support_ticket';
     }

--- a/src/Form/Type/TeamApplicationType.php
+++ b/src/Form/Type/TeamApplicationType.php
@@ -54,7 +54,7 @@ class TeamApplicationType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'app_bundle_team_application_type';
     }

--- a/src/Form/Type/TeamInterestType.php
+++ b/src/Form/Type/TeamInterestType.php
@@ -57,7 +57,7 @@ class TeamInterestType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'App_teaminterest';
     }

--- a/src/Form/Type/TelType.php
+++ b/src/Form/Type/TelType.php
@@ -12,7 +12,7 @@ class TelType extends AbstractType
         return TextType::class;
     }
     
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'tel';
     }

--- a/src/Form/Type/UserCompanyEmailType.php
+++ b/src/Form/Type/UserCompanyEmailType.php
@@ -25,7 +25,7 @@ class UserCompanyEmailType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'app_bundle_user_company_email_type';
     }

--- a/src/Form/Type/UserDataForSubstituteType.php
+++ b/src/Form/Type/UserDataForSubstituteType.php
@@ -52,7 +52,7 @@ class UserDataForSubstituteType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'userDataForSubstitute';
     }


### PR DESCRIPTION
### Describe your changes 📖
Adds `string` as return type on Form `getBlockPrefix`.
This fixes this deprecation:
![image](https://user-images.githubusercontent.com/46197518/198553384-ddd37785-b483-4a40-ad1d-67eb43896f09.png)

**Before:**
<img src=https://user-images.githubusercontent.com/46197518/198554389-43e0dade-c154-4a00-a8ef-5dea90503357.png width=300>


**After:**
<img src=https://user-images.githubusercontent.com/46197518/198554300-a2f57ab3-6b33-4227-84ea-2c8dd395f2bf.png width=300>



### Jira ticket: 🔖
VB-142

### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Pipeline runs successfully
- [x] Sonarcloud scan passes
- [X] Unit tests passes (note: not applicable yet)
