### PR TITLE
fix deprecation: use getMainRequest

### DIFF
--- a/src/Service/GeoLocation.php
+++ b/src/Service/GeoLocation.php
@@ -118,7 +118,7 @@ class GeoLocation
 
     public function findCoordinates($ip)
     {
-        $ignoreGeo = $this->requestStack->getMasterRequest()->headers->get('ignore-geo');
+        $ignoreGeo = $this->requestStack->getMainRequest()->headers->get('ignore-geo');
         if (!$this->ipinfoToken || $ignoreGeo) {
             return null;
         }
@@ -193,9 +193,8 @@ class GeoLocation
             return $request->server->get('HTTP_FORWARDED');
         } elseif ($request->server->get('REMOTE_ADDR') !== null) {
             return $request->server->get('REMOTE_ADDR');
-        } else {
-            return null;
         }
+        return null;
     }
 
     private function ipIsFromAnIgnoredAsn($response) : bool

--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -151,7 +151,7 @@ class LogService implements LoggerInterface
 
     private function createAttachmentData($level, $message, array $data): array
     {
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
         $method = $request ? $request->getMethod() : '';
         $path = $request ? $request->getPathInfo() : '???';
         if ('staging' === $this->env) {

--- a/tests/Service/GeoLocationTest.php
+++ b/tests/Service/GeoLocationTest.php
@@ -59,7 +59,7 @@ class GeoLocationTest extends TestCase
 
         $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStack->expects($this->any())
-                     ->method('getMasterRequest')
+                     ->method('getMainRequest')
                      ->willReturn(new class {
                          public $headers;
 


### PR DESCRIPTION
### Describe your changes 📖
`getMasterRequest()` is deprecated in favour of `getMainRequest()`.

**Tests before:**
<img src="https://user-images.githubusercontent.com/46197518/198676427-40c08518-9ea8-4ff5-9758-fa85f912c03f.png" width=300>

**Tests after:**
<img src="https://user-images.githubusercontent.com/46197518/198676363-cd295847-9a08-4587-ab47-afe7c948e071.png" width=300>

### Jira ticket: 🔖
VB-145

### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Pipeline runs successfully
- [x] Sonarcloud scan passes
- [X] Unit tests passes (note: not applicable yet)
