### PR TITLE
fix: Rename getUserName to getUserIdentifier

### DIFF
--- a/src/Controller/SsoController.php
+++ b/src/Controller/SsoController.php
@@ -46,7 +46,7 @@ class SsoController extends BaseController
 
         return new JsonResponse([
             'name' => $user->getFullName(),
-            'username' => $user->getUsername(),
+            'username' => $user->getUserIdentifier(),
             'email' => $user->getEmail(),
             'companyEmail' => $user->getCompanyEmail(),
         ]);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -398,9 +398,21 @@ class User implements EquatableInterface, UserInterface, Serializable
      *
      * @return string
      */
-    public function getUserName()
+    public function getUserIdentifier(): string
     {
         return $this->user_name;
+    }
+
+    /**
+     * @Deprecated -> remove when upgraded to Symfony 6.0
+     * Required for now because UserInterface has this method.
+     * DO NOT use this method. Use "getUserIdentifier()" instead.
+     *
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return 'not-in-use'; // just to ensure that function is not being used
     }
 
     /**
@@ -868,6 +880,6 @@ class User implements EquatableInterface, UserInterface, Serializable
 
     public function isEqualTo(UserInterface $user)
     {
-        return $this->password === $user->getPassword() && $this->user_name === $user->getUsername();
+        return $this->password === $user->getPassword() && $this->user_name === $user->getUserIdentifier();
     }
 }

--- a/src/Service/UserRegistration.php
+++ b/src/Service/UserRegistration.php
@@ -70,7 +70,7 @@ class UserRegistration
             return null;
         }
 
-        if ($user->getUserName() === null) {
+        if ($user->getUserIdentifier() === null) {
             // Set default username to email
             $user->setUserName($user->getEmail());
         }

--- a/tests/Entity/AssistantHistoryEntityUnitTest.php
+++ b/tests/Entity/AssistantHistoryEntityUnitTest.php
@@ -29,7 +29,7 @@ class AssistantHistoryEntityUnitTest extends TestCase
         $assistantHistory->setUser($user);
 
         // Assert the result
-        $this->assertEquals('petjo', $assistantHistory->getUser()->getUsername());
+        $this->assertEquals('petjo', $assistantHistory->getUser()->getUserIdentifier());
     }
 
     // Check whether the setSemester function is working correctly

--- a/tests/Entity/UserEntityUnitTest.php
+++ b/tests/Entity/UserEntityUnitTest.php
@@ -118,7 +118,7 @@ class UserEntityUnitTest extends TestCase
         $user->setUserName('petjo123');
 
         // Assert the result
-        $this->assertEquals('petjo123', $user->getUserName());
+        $this->assertEquals('petjo123', $user->getUserIdentifier());
     }
 
     // Check whether the setFieldOfStudy function is working correctly


### PR DESCRIPTION
### Describe your changes 📖
Function `getUserName` is now to be named `getUserIdentifier`, new from Symfony 5.3. The old name throw errors starting from 6.0.

To satisfy the use of `UserInteface`, I've for now left the function in place, although made it return `not-in-use`. Remove this function when we have upgraded to Symfony 6.0

**Before this PR:**
<img src="https://user-images.githubusercontent.com/46197518/198689840-220915a2-9286-4482-a3be-c85d37571dad.png" width=300>

**After this PR:**
<img src="https://user-images.githubusercontent.com/46197518/198690447-f15aabd9-e1f8-4817-969c-b629048d07be.png" width=300>

### Jira ticket: 🔖
VB-144

### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Pipeline runs successfully
- [x] Sonarcloud scan passes
- [X] Unit tests passes (note: not applicable yet)
