### PR TITLE
add return type int to getOrder

### DIFF
--- a/src/DataFixtures/LoadAccessRuleData.php
+++ b/src/DataFixtures/LoadAccessRuleData.php
@@ -23,7 +23,7 @@ class LoadAccessRuleData extends AbstractFixture implements OrderedFixtureInterf
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/src/DataFixtures/LoadAdmissionPeriodData.php
+++ b/src/DataFixtures/LoadAdmissionPeriodData.php
@@ -98,7 +98,7 @@ class LoadAdmissionPeriodData extends AbstractFixture implements OrderedFixtureI
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/src/DataFixtures/LoadAdmissionSubscriberData.php
+++ b/src/DataFixtures/LoadAdmissionSubscriberData.php
@@ -26,7 +26,7 @@ class LoadAdmissionSubscriberData extends AbstractFixture implements OrderedFixt
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadApplicationData.php
+++ b/src/DataFixtures/LoadApplicationData.php
@@ -288,7 +288,7 @@ class LoadApplicationData extends AbstractFixture implements OrderedFixtureInter
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadAssistantHistoryData.php
+++ b/src/DataFixtures/LoadAssistantHistoryData.php
@@ -56,7 +56,7 @@ class LoadAssistantHistoryData extends AbstractFixture implements OrderedFixture
         $this->addReference('ah-1', $ah1);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadCertificateRequestData.php
+++ b/src/DataFixtures/LoadCertificateRequestData.php
@@ -19,7 +19,7 @@ class LoadCertificateRequestData extends AbstractFixture implements OrderedFixtu
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadDepartmentData.php
+++ b/src/DataFixtures/LoadDepartmentData.php
@@ -79,7 +79,7 @@ class LoadDepartmentData extends AbstractFixture implements OrderedFixtureInterf
         $this->addReference('dep-4', $department4);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 2;
     }

--- a/src/DataFixtures/LoadExecutiveBoardData.php
+++ b/src/DataFixtures/LoadExecutiveBoardData.php
@@ -52,7 +52,7 @@ class LoadExecutiveBoardData extends AbstractFixture implements OrderedFixtureIn
         $this->addReference('board', $board);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/DataFixtures/LoadExecutiveBoardMembershipData.php
+++ b/src/DataFixtures/LoadExecutiveBoardMembershipData.php
@@ -44,7 +44,7 @@ class LoadExecutiveBoardMembershipData extends AbstractFixture implements Ordere
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadFieldOfStudyData.php
+++ b/src/DataFixtures/LoadFieldOfStudyData.php
@@ -50,7 +50,7 @@ class LoadFieldOfStudyData extends AbstractFixture implements OrderedFixtureInte
         $this->addReference('fos-5', $fos5);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/DataFixtures/LoadInfoMeetingData.php
+++ b/src/DataFixtures/LoadInfoMeetingData.php
@@ -43,7 +43,7 @@ class LoadInfoMeetingData extends AbstractFixture implements ContainerAwareInter
      *
      * @return integer
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 28;
     }

--- a/src/DataFixtures/LoadInterviewQuestionData.php
+++ b/src/DataFixtures/LoadInterviewQuestionData.php
@@ -63,7 +63,7 @@ class LoadInterviewQuestionData extends AbstractFixture implements OrderedFixtur
         $this->setReference('iq-8', $question8);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/src/DataFixtures/LoadInterviewSchemaData.php
+++ b/src/DataFixtures/LoadInterviewSchemaData.php
@@ -35,7 +35,7 @@ class LoadInterviewSchemaData extends AbstractFixture implements OrderedFixtureI
         $this->setReference('ischema-2', $schema2);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/DataFixtures/LoadPositionData.php
+++ b/src/DataFixtures/LoadPositionData.php
@@ -25,7 +25,7 @@ class LoadPositionData extends AbstractFixture implements OrderedFixtureInterfac
         $this->addReference('position-2', $position2);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/src/DataFixtures/LoadReceiptData.php
+++ b/src/DataFixtures/LoadReceiptData.php
@@ -114,7 +114,7 @@ class LoadReceiptData extends AbstractFixture implements OrderedFixtureInterface
         $this->addReference('rec-superadmin', $receiptSuperAdmin);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 20;
     }

--- a/src/DataFixtures/LoadSchoolCapacityData.php
+++ b/src/DataFixtures/LoadSchoolCapacityData.php
@@ -31,7 +31,7 @@ class LoadSchoolCapacityData extends AbstractFixture implements OrderedFixtureIn
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/src/DataFixtures/LoadSchoolData.php
+++ b/src/DataFixtures/LoadSchoolData.php
@@ -61,7 +61,7 @@ class LoadSchoolData extends AbstractFixture implements OrderedFixtureInterface
         $this->addReference('school-4', $school4);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/src/DataFixtures/LoadSemesterData.php
+++ b/src/DataFixtures/LoadSemesterData.php
@@ -50,7 +50,7 @@ class LoadSemesterData extends AbstractFixture implements OrderedFixtureInterfac
         $this->addReference('semester-3', $semester3);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/DataFixtures/LoadSponsorData.php
+++ b/src/DataFixtures/LoadSponsorData.php
@@ -40,7 +40,7 @@ class LoadSponsorData extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/src/DataFixtures/LoadTeamApplicationData.php
+++ b/src/DataFixtures/LoadTeamApplicationData.php
@@ -25,7 +25,7 @@ class LoadTeamApplicationData extends AbstractFixture implements OrderedFixtureI
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/src/DataFixtures/LoadTeamData.php
+++ b/src/DataFixtures/LoadTeamData.php
@@ -159,7 +159,7 @@ class LoadTeamData extends AbstractFixture implements OrderedFixtureInterface
         $this->addReference('team-2', $team2);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 3;
     }

--- a/src/DataFixtures/LoadTeamInterestData.php
+++ b/src/DataFixtures/LoadTeamInterestData.php
@@ -36,7 +36,7 @@ class LoadTeamInterestData extends AbstractFixture implements OrderedFixtureInte
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadTeamMembershipData.php
+++ b/src/DataFixtures/LoadTeamMembershipData.php
@@ -110,7 +110,7 @@ class LoadTeamMembershipData extends AbstractFixture implements OrderedFixtureIn
         $this->addReference('tm-3', $tm3);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/src/DataFixtures/LoadUserData.php
+++ b/src/DataFixtures/LoadUserData.php
@@ -489,7 +489,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, C
         $this->setReference('user-admin', $userAdmin);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }


### PR DESCRIPTION
### Describe your changes 📖
Add `int` as return type to `getOrder` functions.

### Jira ticket: 🔖


### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Pipeline runs successfully
- [x] Sonarcloud scan passes
- [X] Unit tests passes (note: not applicable yet)
