### PR TITLE
Remove twig 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
         "symfony/validator": "5.4.*",
         "symfony/web-link": "5.4.*",
         "symfony/yaml": "5.4.*",
-        "twig/extra-bundle": "^2.12|^3.0",
-        "twig/twig": "^2.12|^3.0"
+        "twig/extra-bundle": "^3.4",
+        "twig/twig": "^3.4"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^6",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "symfony/browser-kit": "^5.4",
         "symfony/css-selector": "^5.4",
         "symfony/debug-bundle": "^5.4",
-        "symfony/maker-bundle": "^1.0",
+        "symfony/maker-bundle": "^1.43",
         "symfony/phpunit-bridge": "^6.2",
         "symfony/stopwatch": "^5.4",
         "symfony/var-dumper": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32b05d30eee7723aaf6bfc42e024c141",
+    "content-hash": "106c92e419217a7123615d8958184aea",
     "packages": [
         {
             "name": "api-platform/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "106c92e419217a7123615d8958184aea",
+    "content-hash": "f02eb0676edbfab25fc5aa104524d554",
     "packages": [
         {
             "name": "api-platform/core",


### PR DESCRIPTION
### Describe your changes 📖
Remove support for Twig 2.
We now support Twig v3 only.

### Linear ticket: 🔖
VB-XXX

### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Pipeline runs successfully
- [x] Sonarcloud scan passes
- [X] Unit tests passes (note: not applicable yet)
