### PR TITLE
chore: replace getDoctrine with ManagerRegistry

### DIFF
--- a/src/Controller/AccessRuleController.php
+++ b/src/Controller/AccessRuleController.php
@@ -20,8 +20,7 @@ class AccessRuleController extends AbstractController
         private readonly AccessControlService $accessControlService,
         private readonly ReversedRoleHierarchy $reversedRoleHierarchy,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function index(): Response

--- a/src/Controller/AccessRuleController.php
+++ b/src/Controller/AccessRuleController.php
@@ -16,7 +16,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AccessRuleController extends AbstractController
 {
-    public function __construct(private readonly AccessControlService $accessControlService, private readonly ReversedRoleHierarchy $reversedRoleHierarchy, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly AccessControlService $accessControlService,
+        private readonly ReversedRoleHierarchy $reversedRoleHierarchy,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/AccessRuleController.php
+++ b/src/Controller/AccessRuleController.php
@@ -9,21 +9,22 @@ use App\Form\Type\RoutingAccessRuleType;
 use App\Role\ReversedRoleHierarchy;
 use App\Role\Roles;
 use App\Service\AccessControlService;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AccessRuleController extends AbstractController
 {
-    public function __construct(private readonly AccessControlService $accessControlService, private readonly ReversedRoleHierarchy $reversedRoleHierarchy)
+    public function __construct(private readonly AccessControlService $accessControlService, private readonly ReversedRoleHierarchy $reversedRoleHierarchy, private readonly ManagerRegistry $doctrine)
     {
     }
 
     public function index(): Response
     {
-        $customRules = $this->getDoctrine()->getRepository(AccessRule::class)->findCustomRules();
-        $routingRules = $this->getDoctrine()->getRepository(AccessRule::class)->findRoutingRules();
-        $unhandledRules = $this->getDoctrine()->getRepository(UnhandledAccessRule::class)->findAll();
+        $customRules = $this->doctrine->getRepository(AccessRule::class)->findCustomRules();
+        $routingRules = $this->doctrine->getRepository(AccessRule::class)->findRoutingRules();
+        $unhandledRules = $this->doctrine->getRepository(UnhandledAccessRule::class)->findAll();
 
         return $this->render('admin/access_rule/index.html.twig', [
             'customRules' => $customRules,
@@ -107,7 +108,7 @@ class AccessRuleController extends AbstractController
 
     public function delete(AccessRule $accessRule): Response
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($accessRule);
         $em->flush();
 

--- a/src/Controller/AdmissionAdminController.php
+++ b/src/Controller/AdmissionAdminController.php
@@ -28,8 +28,7 @@ class AdmissionAdminController extends BaseController
         private readonly InterviewCounter $InterviewCounter,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/AdmissionAdminController.php
+++ b/src/Controller/AdmissionAdminController.php
@@ -24,7 +24,11 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class AdmissionAdminController extends BaseController
 {
-    public function __construct(private readonly InterviewCounter $InterviewCounter, private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly InterviewCounter $InterviewCounter,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/AdmissionPeriodController.php
+++ b/src/Controller/AdmissionPeriodController.php
@@ -6,12 +6,17 @@ use App\Entity\AdmissionPeriod;
 use App\Entity\Department;
 use App\Form\Type\CreateAdmissionPeriodType;
 use App\Form\Type\EditAdmissionPeriodType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdmissionPeriodController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(): Response
     {
         // Finds the departmentId for the current logged-in user
@@ -22,7 +27,7 @@ class AdmissionPeriodController extends BaseController
 
     public function showByDepartment(Department $department): Response
     {
-        $admissionPeriods = $this->getDoctrine()
+        $admissionPeriods = $this->doctrine
             ->getRepository(AdmissionPeriod::class)
             ->findByDepartmentOrderedByTime($department);
 
@@ -52,7 +57,7 @@ class AdmissionPeriodController extends BaseController
         if ($form->isSubmitted() && $form->isValid() && !$exists) {
             $admissionPeriod->setDepartment($department);
 
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($admissionPeriod);
             $em->flush();
 
@@ -74,7 +79,7 @@ class AdmissionPeriodController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($admissionPeriod);
             $em->flush();
 
@@ -90,7 +95,7 @@ class AdmissionPeriodController extends BaseController
 
     public function delete(AdmissionPeriod $admissionPeriod): RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $infoMeeting = $admissionPeriod->getInfoMeeting();
         if ($infoMeeting) {
             $em->remove($infoMeeting);

--- a/src/Controller/AdmissionSubscriberController.php
+++ b/src/Controller/AdmissionSubscriberController.php
@@ -6,12 +6,17 @@ use App\Entity\AdmissionSubscriber;
 use App\Entity\Department;
 use App\Form\Type\AdmissionSubscriberType;
 use App\Service\AdmissionNotifier;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class AdmissionSubscriberController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function subscribePage(Request $request, Department $department)
     {
         $subscriber = new AdmissionSubscriber();
@@ -45,7 +50,7 @@ class AdmissionSubscriberController extends BaseController
         if (!$email || !$departmentId) {
             return new JsonResponse('Email or department missing', 400);
         }
-        $department = $this->getDoctrine()->getRepository(Department::class)->find($departmentId);
+        $department = $this->doctrine->getRepository(Department::class)->find($departmentId);
         if (!$department) {
             return new JsonResponse('Invalid department', 400);
         }
@@ -61,14 +66,14 @@ class AdmissionSubscriberController extends BaseController
 
     public function unsubscribe($code): RedirectResponse
     {
-        $subscriber = $this->getDoctrine()->getRepository(AdmissionSubscriber::class)->findByUnsubscribeCode($code);
+        $subscriber = $this->doctrine->getRepository(AdmissionSubscriber::class)->findByUnsubscribeCode($code);
         $this->addFlash('title', 'Opptaksvarsel - Avmelding');
         if (!$subscriber) {
             $this->addFlash('message', 'Du vil ikke lengre motta varsler om opptak');
         } else {
             $email = $subscriber->getEmail();
             $this->addFlash('message', "Du vil ikke lengre motta varsler om opptak på $email");
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->remove($subscriber);
             $em->flush();
         }

--- a/src/Controller/Api/AccountController.php
+++ b/src/Controller/Api/AccountController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\DataTransferObject\UserDto;
 use App\Entity\User;
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -14,7 +15,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class AccountController extends BaseController
 {
-    public function __construct(private readonly TokenStorageInterface $tokenStorage, private readonly RequestStack $requestStack)
+    public function __construct(private readonly TokenStorageInterface $tokenStorage, private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -33,7 +34,7 @@ class AccountController extends BaseController
         }
 
         try {
-            $user = $this->getDoctrine()->getRepository(User::class)->findByUsernameOrEmail($username);
+            $user = $this->doctrine->getRepository(User::class)->findByUsernameOrEmail($username);
         } catch (NoResultException) {
             $response->setStatusCode(401);
             $response->setContent('Username does not exist');

--- a/src/Controller/Api/AccountController.php
+++ b/src/Controller/Api/AccountController.php
@@ -15,7 +15,9 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class AccountController extends BaseController
 {
-    public function __construct(private readonly TokenStorageInterface $tokenStorage, private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
+    public function __construct(private readonly TokenStorageInterface $tokenStorage,
+                                private readonly RequestStack $requestStack,
+                                private readonly ManagerRegistry $doctrine)
     {
     }
 

--- a/src/Controller/ApplicationStatisticsController.php
+++ b/src/Controller/ApplicationStatisticsController.php
@@ -6,12 +6,13 @@ use App\Entity\AdmissionPeriod;
 use App\Service\ApplicationData;
 use App\Service\AssistantHistoryData;
 use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ApplicationStatisticsController extends BaseController
 {
-    public function __construct(private readonly AssistantHistoryData $AssistantHistoryData, private readonly ApplicationData $ApplicationData)
+    public function __construct(private readonly AssistantHistoryData $AssistantHistoryData, private readonly ApplicationData $ApplicationData, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -22,7 +23,7 @@ class ApplicationStatisticsController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()
+        $admissionPeriod = $this->doctrine
             ->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 

--- a/src/Controller/ApplicationStatisticsController.php
+++ b/src/Controller/ApplicationStatisticsController.php
@@ -12,7 +12,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ApplicationStatisticsController extends BaseController
 {
-    public function __construct(private readonly AssistantHistoryData $AssistantHistoryData, private readonly ApplicationData $ApplicationData, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly AssistantHistoryData $AssistantHistoryData,
+        private readonly ApplicationData $ApplicationData,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ApplicationStatisticsController.php
+++ b/src/Controller/ApplicationStatisticsController.php
@@ -16,8 +16,7 @@ class ApplicationStatisticsController extends BaseController
         private readonly AssistantHistoryData $AssistantHistoryData,
         private readonly ApplicationData $ApplicationData,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/AssistantController.php
+++ b/src/Controller/AssistantController.php
@@ -29,8 +29,7 @@ class AssistantController extends BaseController
         private readonly KernelInterface $kernel,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/AssistantController.php
+++ b/src/Controller/AssistantController.php
@@ -22,7 +22,14 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class AssistantController extends BaseController
 {
-    public function __construct(private readonly ApplicationAdmission $applicationAdmission, private readonly GeoLocation $geoLocation, private readonly FilterService $filterService, private readonly KernelInterface $kernel, private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly ApplicationAdmission $applicationAdmission,
+        private readonly GeoLocation $geoLocation,
+        private readonly FilterService $filterService,
+        private readonly KernelInterface $kernel,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/AssistantController.php
+++ b/src/Controller/AssistantController.php
@@ -13,6 +13,7 @@ use App\Service\FilterService;
 use App\Service\GeoLocation;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +22,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class AssistantController extends BaseController
 {
-    public function __construct(private readonly ApplicationAdmission $applicationAdmission, private readonly GeoLocation $geoLocation, private readonly FilterService $filterService, private readonly KernelInterface $kernel, private readonly EventDispatcherInterface $eventDispatcher)
+    public function __construct(private readonly ApplicationAdmission $applicationAdmission, private readonly GeoLocation $geoLocation, private readonly FilterService $filterService, private readonly KernelInterface $kernel, private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -45,7 +46,7 @@ class AssistantController extends BaseController
     public function admissionCaseInsensitive(Request $request, $city): Response
     {
         $city = str_replace(['æ', 'ø', 'å'], ['Æ', 'Ø', 'Å'], (string) $city); // Make sqlite happy
-        $department = $this->getDoctrine()
+        $department = $this->doctrine
                 ->getRepository(Department::class)
                 ->findOneByCityCaseInsensitive($city);
         if ($department !== null) {
@@ -65,7 +66,7 @@ class AssistantController extends BaseController
         bool $scrollToAdmissionForm = false
     ): Response {
         $admissionManager = $this->applicationAdmission;
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
 
         $departments = $em->getRepository(Department::class)->findActive();
         $departments = $this->geoLocation->sortDepartmentsByDistanceFromClient($departments);
@@ -149,7 +150,7 @@ class AssistantController extends BaseController
             return $this->index($request, $department);
         }
         $admissionManager = $this->get(ApplicationAdmission::class);
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $application = new Application();
 
         $form = $this->get('form.factory')->createNamedBuilder('application_' . $department->getId(), ApplicationType::class, $application, [

--- a/src/Controller/AssistantHistoryController.php
+++ b/src/Controller/AssistantHistoryController.php
@@ -15,8 +15,7 @@ class AssistantHistoryController extends BaseController
     public function __construct(
         private readonly LogService $logService,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function delete(AssistantHistory $assistantHistory): RedirectResponse

--- a/src/Controller/AssistantHistoryController.php
+++ b/src/Controller/AssistantHistoryController.php
@@ -12,7 +12,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AssistantHistoryController extends BaseController
 {
-    public function __construct(private readonly LogService $logService, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly LogService $logService,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/AssistantHistoryController.php
+++ b/src/Controller/AssistantHistoryController.php
@@ -6,12 +6,13 @@ use App\Entity\AssistantHistory;
 use App\Form\Type\CreateAssistantHistoryType;
 use App\Role\Roles;
 use App\Service\LogService;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class AssistantHistoryController extends BaseController
 {
-    public function __construct(private readonly LogService $logService)
+    public function __construct(private readonly LogService $logService, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -21,7 +22,7 @@ class AssistantHistoryController extends BaseController
             $this->createAccessDeniedException();
         }
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($assistantHistory);
         $em->flush();
 
@@ -35,7 +36,7 @@ class AssistantHistoryController extends BaseController
 
     public function edit(Request $request, AssistantHistory $assistantHistory)
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
 
         $department = $assistantHistory->getUser()->getDepartment();
         $form = $this->createForm(CreateAssistantHistoryType::class, $assistantHistory, [

--- a/src/Controller/AssistantSchedulingController.php
+++ b/src/Controller/AssistantSchedulingController.php
@@ -9,11 +9,16 @@ use App\Entity\Application;
 use App\Entity\SchoolCapacity;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class AssistantSchedulingController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function index(): Response
     {
         return $this->render('assistant_scheduling/index.html.twig');
@@ -28,9 +33,9 @@ class AssistantSchedulingController extends BaseController
         $user = $this->getUser();
 
         $currentSemester = $this->getCurrentSemester();
-        $currentAdmissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
+        $currentAdmissionPeriod = $this->doctrine->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($user->getDepartment(), $currentSemester);
-        $applications = $this->getDoctrine()->getRepository(Application::class)->findAllAllocatableApplicationsByAdmissionPeriod($currentAdmissionPeriod);
+        $applications = $this->doctrine->getRepository(Application::class)->findAllAllocatableApplicationsByAdmissionPeriod($currentAdmissionPeriod);
 
         $assistants = $this->getAssistantAvailableDays($applications);
 
@@ -95,7 +100,7 @@ class AssistantSchedulingController extends BaseController
         $user = $this->getUser();
         $department = $user->getFieldOfStudy()->getDepartment();
         $currentSemester = $this->getCurrentSemester();
-        $allCurrentSchoolCapacities = $this->getDoctrine()
+        $allCurrentSchoolCapacities = $this->doctrine
             ->getRepository(SchoolCapacity::class)->findByDepartmentAndSemester($department, $currentSemester);
         $schools = $this->generateSchoolsFromSchoolCapacities($allCurrentSchoolCapacities);
 

--- a/src/Controller/BoardAndTeamController.php
+++ b/src/Controller/BoardAndTeamController.php
@@ -14,8 +14,7 @@ class BoardAndTeamController extends BaseController
     public function __construct(
         private readonly GeoLocation $geoLocation,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(): Response

--- a/src/Controller/BoardAndTeamController.php
+++ b/src/Controller/BoardAndTeamController.php
@@ -6,20 +6,21 @@ use App\Entity\Department;
 use App\Entity\ExecutiveBoard;
 use App\Entity\User;
 use App\Service\GeoLocation;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Response;
 
 class BoardAndTeamController extends BaseController
 {
-    public function __construct(private readonly GeoLocation $geoLocation)
+    public function __construct(private readonly GeoLocation $geoLocation, private readonly ManagerRegistry $doctrine)
     {
     }
 
     public function show(): Response
     {
         // Find all departments
-        $departments = $this->getDoctrine()->getRepository(Department::class)->findActive();
+        $departments = $this->doctrine->getRepository(Department::class)->findActive();
         $departments = $this->geoLocation->sortDepartmentsByDistanceFromClient($departments);
-        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
+        $board = $this->doctrine->getRepository(ExecutiveBoard::class)->findBoard();
 
         $numberOfTeams = 0;
         foreach ($departments as $department) {
@@ -29,7 +30,7 @@ class BoardAndTeamController extends BaseController
         $departmentStats = [];
         foreach ($departments as $department) {
             $currentSemester = $this->getCurrentSemester();
-            $userRepository = $this->getDoctrine()->getRepository(User::class);
+            $userRepository = $this->doctrine->getRepository(User::class);
             $departmentStats[$department->getCity()] = [
                 'numTeamMembers' => sizeof($userRepository->findUsersInDepartmentWithTeamMembershipInSemester($department, $currentSemester)),
                 'numAssistants' => sizeof($userRepository->findUsersWithAssistantHistoryInDepartmentAndSemester($department, $currentSemester)),

--- a/src/Controller/BoardAndTeamController.php
+++ b/src/Controller/BoardAndTeamController.php
@@ -11,7 +11,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BoardAndTeamController extends BaseController
 {
-    public function __construct(private readonly GeoLocation $geoLocation, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly GeoLocation $geoLocation,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/CertificateController.php
+++ b/src/Controller/CertificateController.php
@@ -17,8 +17,7 @@ class CertificateController extends BaseController
     public function __construct(
         private readonly FileUploader $fileUploader,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(Request $request): RedirectResponse|Response

--- a/src/Controller/CertificateController.php
+++ b/src/Controller/CertificateController.php
@@ -7,13 +7,14 @@ use App\Entity\CertificateRequest;
 use App\Entity\Signature;
 use App\Form\Type\CreateSignatureType;
 use App\Service\FileUploader;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CertificateController extends BaseController
 {
-    public function __construct(private readonly FileUploader $fileUploader)
+    public function __construct(private readonly FileUploader $fileUploader, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -21,11 +22,11 @@ class CertificateController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
 
         $assistants = $em->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($department, $semester);
 
-        $signature = $this->getDoctrine()->getRepository(Signature::class)->findByUser($this->getUser());
+        $signature = $this->doctrine->getRepository(Signature::class)->findByUser($this->getUser());
         $oldPath = '';
         if ($signature === null) {
             $signature = new Signature();
@@ -49,7 +50,7 @@ class CertificateController extends BaseController
             }
 
             $signature->setUser($this->getUser());
-            $manager = $this->getDoctrine()->getManager();
+            $manager = $this->doctrine->getManager();
             $manager->persist($signature);
             $manager->flush();
 
@@ -59,7 +60,7 @@ class CertificateController extends BaseController
         }
 
         // Finds all the certificate requests
-        $certificateRequests = $this->getDoctrine()->getRepository(CertificateRequest::class)->findAll();
+        $certificateRequests = $this->doctrine->getRepository(CertificateRequest::class)->findAll();
 
         return $this->render('certificate/index.html.twig', [
             'certificateRequests' => $certificateRequests,

--- a/src/Controller/CertificateController.php
+++ b/src/Controller/CertificateController.php
@@ -14,7 +14,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CertificateController extends BaseController
 {
-    public function __construct(private readonly FileUploader $fileUploader, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly FileUploader $fileUploader,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -9,13 +9,14 @@ use App\Event\SupportTicketCreatedEvent;
 use App\Form\Type\SupportTicketType;
 use App\Service\GeoLocation;
 use App\Service\LogService;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ContactController extends BaseController
 {
-    public function __construct(private readonly GeoLocation $geoLocation, private readonly LogService $logService, private readonly EventDispatcherInterface $eventDispatcher)
+    public function __construct(private readonly GeoLocation $geoLocation, private readonly LogService $logService, private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -23,13 +24,13 @@ class ContactController extends BaseController
     {
         if ($department === null) {
             $department = $this->geoLocation
-                ->findNearestDepartment($this->getDoctrine()->getRepository(Department::class)->findAll());
+                ->findNearestDepartment($this->doctrine->getRepository(Department::class)->findAll());
         }
 
         $supportTicket = new SupportTicket();
         $supportTicket->setDepartment($department);
         $form = $this->createForm(SupportTicketType::class, $supportTicket, [
-            'department_repository' => $this->getDoctrine()->getRepository(Department::class),
+            'department_repository' => $this->doctrine->getRepository(Department::class),
         ]);
 
         $form->handleRequest($request);
@@ -43,7 +44,7 @@ class ContactController extends BaseController
             return $this->redirectToRoute('contact_department', ['id' => $supportTicket->getDepartment()->getId()]);
         }
 
-        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
+        $board = $this->doctrine->getRepository(ExecutiveBoard::class)->findBoard();
         $scrollToForm = $form->isSubmitted() && !$form->isValid();
 
         return $this->render('contact/index.html.twig', [

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -21,8 +21,7 @@ class ContactController extends BaseController
         private readonly LogService $logService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function index(Request $request, Department $department = null): Response

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -16,7 +16,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ContactController extends BaseController
 {
-    public function __construct(private readonly GeoLocation $geoLocation, private readonly LogService $logService, private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly GeoLocation $geoLocation,
+        private readonly LogService $logService,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ControlPanelController.php
+++ b/src/Controller/ControlPanelController.php
@@ -4,12 +4,13 @@ namespace App\Controller;
 
 use App\Entity\AdmissionPeriod;
 use App\Service\SbsData;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ControlPanelController extends BaseController
 {
-    public function __construct(private readonly SbsData $sbsData)
+    public function __construct(private readonly SbsData $sbsData, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -18,7 +19,7 @@ class ControlPanelController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
 
-        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
+        $admissionPeriod = $this->doctrine->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         // Return the view to be rendered

--- a/src/Controller/ControlPanelController.php
+++ b/src/Controller/ControlPanelController.php
@@ -10,7 +10,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ControlPanelController extends BaseController
 {
-    public function __construct(private readonly SbsData $sbsData, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly SbsData $sbsData,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ControlPanelController.php
+++ b/src/Controller/ControlPanelController.php
@@ -13,8 +13,7 @@ class ControlPanelController extends BaseController
     public function __construct(
         private readonly SbsData $sbsData,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(Request $request): Response

--- a/src/Controller/DepartmentController.php
+++ b/src/Controller/DepartmentController.php
@@ -4,12 +4,17 @@ namespace App\Controller;
 
 use App\Entity\Department;
 use App\Form\Type\CreateDepartmentType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class DepartmentController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(): Response
     {
         return $this->render('department_admin/index.html.twig', []);
@@ -24,7 +29,7 @@ class DepartmentController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($department);
             $em->flush();
 
@@ -40,7 +45,7 @@ class DepartmentController extends BaseController
 
     public function deleteDepartmentById(Department $department): RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($department);
         $em->flush();
 
@@ -56,7 +61,7 @@ class DepartmentController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($department);
             $em->flush();
 

--- a/src/Controller/ExecutiveBoardController.php
+++ b/src/Controller/ExecutiveBoardController.php
@@ -15,7 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExecutiveBoardController extends BaseController
 {
-    public function __construct(private readonly RoleManager $roleManager, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly RoleManager $roleManager,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ExecutiveBoardController.php
+++ b/src/Controller/ExecutiveBoardController.php
@@ -18,8 +18,7 @@ class ExecutiveBoardController extends BaseController
     public function __construct(
         private readonly RoleManager $roleManager,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(): Response

--- a/src/Controller/ExecutiveBoardController.php
+++ b/src/Controller/ExecutiveBoardController.php
@@ -8,19 +8,20 @@ use App\Entity\ExecutiveBoardMembership;
 use App\Form\Type\CreateExecutiveBoardMembershipType;
 use App\Form\Type\CreateExecutiveBoardType;
 use App\Service\RoleManager;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ExecutiveBoardController extends BaseController
 {
-    public function __construct(private readonly RoleManager $roleManager)
+    public function __construct(private readonly RoleManager $roleManager, private readonly ManagerRegistry $doctrine)
     {
     }
 
     public function show(): Response
     {
-        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
+        $board = $this->doctrine->getRepository(ExecutiveBoard::class)->findBoard();
 
         return $this->render('team/team_page.html.twig', [
             'team' => $board,
@@ -29,8 +30,8 @@ class ExecutiveBoardController extends BaseController
 
     public function showAdmin(): Response
     {
-        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
-        $members = $this->getDoctrine()->getRepository(ExecutiveBoardMembership::class)->findAll();
+        $board = $this->doctrine->getRepository(ExecutiveBoard::class)->findBoard();
+        $members = $this->doctrine->getRepository(ExecutiveBoardMembership::class)->findAll();
         $activeMembers = [];
         $inactiveMembers = [];
         foreach ($members as $member) {
@@ -50,7 +51,7 @@ class ExecutiveBoardController extends BaseController
 
     public function addUserToBoard(Request $request, Department $department)
     {
-        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
+        $board = $this->doctrine->getRepository(ExecutiveBoard::class)->findBoard();
 
         // Create a new TeamMembership entity
         $member = new ExecutiveBoardMembership();
@@ -68,7 +69,7 @@ class ExecutiveBoardController extends BaseController
             $member->setBoard($board);
 
             // Persist the board to the database
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($member);
             $em->flush();
 
@@ -87,7 +88,7 @@ class ExecutiveBoardController extends BaseController
 
     public function removeUserFromBoardById(ExecutiveBoardMembership $member): RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($member);
         $em->flush();
 
@@ -98,7 +99,7 @@ class ExecutiveBoardController extends BaseController
 
     public function updateBoard(Request $request)
     {
-        $board = $this->getDoctrine()->getRepository(ExecutiveBoard::class)->findBoard();
+        $board = $this->doctrine->getRepository(ExecutiveBoard::class)->findBoard();
 
         // Create the form
         $form = $this->createForm(CreateExecutiveBoardType::class, $board);
@@ -109,7 +110,7 @@ class ExecutiveBoardController extends BaseController
             // Don't persist if the preview button was clicked
             if (!$form->get('preview')->isClicked()) {
                 // Persist the board to the database
-                $em = $this->getDoctrine()->getManager();
+                $em = $this->doctrine->getManager();
                 $em->persist($board);
                 $em->flush();
 
@@ -138,7 +139,7 @@ class ExecutiveBoardController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($member);
             $em->flush();
 

--- a/src/Controller/ExistingUserAdmissionController.php
+++ b/src/Controller/ExistingUserAdmissionController.php
@@ -20,8 +20,7 @@ class ExistingUserAdmissionController extends BaseController
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ApplicationAdmission $applicationAdmission,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/ExistingUserAdmissionController.php
+++ b/src/Controller/ExistingUserAdmissionController.php
@@ -16,7 +16,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExistingUserAdmissionController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ApplicationAdmission $applicationAdmission, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ApplicationAdmission $applicationAdmission,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ExistingUserAdmissionController.php
+++ b/src/Controller/ExistingUserAdmissionController.php
@@ -8,6 +8,7 @@ use App\Form\Type\ApplicationExistingUserType;
 use App\Service\ApplicationAdmission;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExistingUserAdmissionController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ApplicationAdmission $applicationAdmission)
+    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ApplicationAdmission $applicationAdmission, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -28,7 +29,7 @@ class ExistingUserAdmissionController extends BaseController
     public function show(Request $request)
     {
         $user = $this->getUser();
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $admissionManager = $this->applicationAdmission;
         if ($res = $admissionManager->renderErrorPage($user)) {
             return $res;

--- a/src/Controller/FieldOfStudyController.php
+++ b/src/Controller/FieldOfStudyController.php
@@ -4,16 +4,21 @@ namespace App\Controller;
 
 use App\Entity\FieldOfStudy;
 use App\Form\Type\FieldOfStudyType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class FieldOfStudyController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(): Response
     {
         $department = $this->getUser()->getFieldOfStudy()->getDepartment();
-        $fieldOfStudies = $this->getDoctrine()->getRepository(FieldOfStudy::class)->findByDepartment($department);
+        $fieldOfStudies = $this->doctrine->getRepository(FieldOfStudy::class)->findByDepartment($department);
 
         return $this->render('field_of_study/show_all.html.twig', [
             'fieldOfStudies' => $fieldOfStudies,
@@ -38,7 +43,7 @@ class FieldOfStudyController extends BaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $fieldOfStudy->setDepartment($this->getUser()->getFieldOfStudy()->getDepartment());
-            $manager = $this->getDoctrine()->getManager();
+            $manager = $this->doctrine->getManager();
             $manager->persist($fieldOfStudy);
             $manager->flush();
 

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -5,17 +5,22 @@ namespace App\Controller;
 use App\Entity\Department;
 use App\Entity\User;
 use App\Service\GeoLocation;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Response;
 
 class HomeController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(GeoLocation $geoLocation): Response
     {
-        $assistantsCount = is_countable($this->getDoctrine()->getRepository(User::class)->findAssistants()) ? count($this->getDoctrine()->getRepository(User::class)->findAssistants()) : 0;
-        $teamMembersCount = is_countable($this->getDoctrine()->getRepository(User::class)->findTeamMembers()) ? count($this->getDoctrine()->getRepository(User::class)->findTeamMembers()) : 0;
+        $assistantsCount = is_countable($this->doctrine->getRepository(User::class)->findAssistants()) ? count($this->doctrine->getRepository(User::class)->findAssistants()) : 0;
+        $teamMembersCount = is_countable($this->doctrine->getRepository(User::class)->findTeamMembers()) ? count($this->doctrine->getRepository(User::class)->findTeamMembers()) : 0;
 
-        $departments = $this->getDoctrine()->getRepository(Department::class)->findAll();
-        $departmentsWithActiveAdmission = $this->getDoctrine()->getRepository(Department::class)->findAllWithActiveAdmission();
+        $departments = $this->doctrine->getRepository(Department::class)->findAll();
+        $departmentsWithActiveAdmission = $this->doctrine->getRepository(Department::class)->findAllWithActiveAdmission();
         $departmentsWithActiveAdmission = $geoLocation->sortDepartmentsByDistanceFromClient($departmentsWithActiveAdmission);
         $closestDepartment = $geoLocation->findNearestDepartment($departments);
         $ipWasLocated = $geoLocation->findCoordinatesOfCurrentRequest();

--- a/src/Controller/InterviewController.php
+++ b/src/Controller/InterviewController.php
@@ -33,7 +33,13 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class InterviewController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly InterviewManager $interviewManager, private readonly ReversedRoleHierarchy $reversedRoleHierarchy, private readonly ApplicationManager $applicationManager, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly InterviewManager $interviewManager,
+        private readonly ReversedRoleHierarchy $reversedRoleHierarchy,
+        private readonly ApplicationManager $applicationManager,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/InterviewController.php
+++ b/src/Controller/InterviewController.php
@@ -39,8 +39,7 @@ class InterviewController extends BaseController
         private readonly ReversedRoleHierarchy $reversedRoleHierarchy,
         private readonly ApplicationManager $applicationManager,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function conduct(Request $request, Application $application): RedirectResponse|Response

--- a/src/Controller/InterviewController.php
+++ b/src/Controller/InterviewController.php
@@ -19,6 +19,7 @@ use App\Role\ReversedRoleHierarchy;
 use App\Role\Roles;
 use App\Service\ApplicationManager;
 use App\Service\InterviewManager;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -32,7 +33,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class InterviewController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly InterviewManager $interviewManager, private readonly ReversedRoleHierarchy $reversedRoleHierarchy, private readonly ApplicationManager $applicationManager)
+    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly InterviewManager $interviewManager, private readonly ReversedRoleHierarchy $reversedRoleHierarchy, private readonly ApplicationManager $applicationManager, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -42,7 +43,7 @@ class InterviewController extends BaseController
             throw $this->createNotFoundException();
         }
         $department = $this->getUser()->getDepartment();
-        $teams = $this->getDoctrine()->getRepository(Team::class)->findActiveByDepartment($department);
+        $teams = $this->doctrine->getRepository(Team::class)->findActiveByDepartment($department);
 
         if ($this->getUser() === $application->getUser()) {
             return $this->render('error/control_panel_error.html.twig', ['error' => 'Du kan ikke intervjue deg selv']);
@@ -67,7 +68,7 @@ class InterviewController extends BaseController
             $isNewInterview = !$interview->getInterviewed();
             $interview->setCancelled(false);
 
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($interview);
             $em->flush();
             if ($isNewInterview && $form->get('saveAndSend')->isClicked()) {
@@ -96,7 +97,7 @@ class InterviewController extends BaseController
     public function cancel(Interview $interview): RedirectResponse
     {
         $interview->setCancelled(true);
-        $manager = $this->getDoctrine()->getManager();
+        $manager = $this->doctrine->getManager();
         $manager->persist($interview);
         $manager->flush();
 
@@ -131,7 +132,7 @@ class InterviewController extends BaseController
     {
         $interview->getApplication()->setInterview(null);
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($interview);
         $em->flush();
 
@@ -150,7 +151,7 @@ class InterviewController extends BaseController
         $applicationIds = $request->request->get('application')['id'];
 
         // Get the application objects
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $applications = $em->getRepository(Application::class)->findBy(['id' => $applicationIds]);
 
         // Delete the interviews
@@ -220,7 +221,7 @@ class InterviewController extends BaseController
                 ]);
             }
 
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($interview);
             $em->flush();
 
@@ -266,7 +267,7 @@ class InterviewController extends BaseController
         if ($id === null) {
             throw $this->createNotFoundException();
         }
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $application = $em->getRepository(Application::class)->find($id);
         $user = $application->getUser();
         // Finds all the roles above admin in the hierarchy, used to populate dropdown menu with all admins
@@ -313,7 +314,7 @@ class InterviewController extends BaseController
         //    'roles' => $roles
         ]);
         if ($request->isMethod('POST')) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             // Get the info from the form
             $data = $request->request->all();
             // Get objects from database
@@ -349,7 +350,7 @@ class InterviewController extends BaseController
     public function acceptByResponseCode(Interview $interview): Response
     {
         $interview->acceptInterview();
-        $manager = $this->getDoctrine()->getManager();
+        $manager = $this->doctrine->getManager();
         $manager->persist($interview);
         $manager->flush();
 
@@ -380,7 +381,7 @@ class InterviewController extends BaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $interview->requestNewTime();
-            $manager = $this->getDoctrine()->getManager();
+            $manager = $this->doctrine->getManager();
             $manager->persist($interview);
             $manager->flush();
 
@@ -423,7 +424,7 @@ class InterviewController extends BaseController
             $data = $form->getData();
             $interview->setCancelMessage($data['message']);
             $interview->cancel();
-            $manager = $this->getDoctrine()->getManager();
+            $manager = $this->doctrine->getManager();
             $manager->persist($interview);
             $manager->flush();
 
@@ -451,7 +452,7 @@ class InterviewController extends BaseController
         } catch (\InvalidArgumentException) {
             throw new BadRequestHttpException();
         }
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->flush();
 
         return $this->redirectToRoute(
@@ -481,7 +482,7 @@ class InterviewController extends BaseController
         }
 
         $interview->setCoInterviewer($this->getUser());
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->persist($interview);
         $em->flush();
         $this->eventDispatcher->dispatch(new InterviewEvent($interview), InterviewEvent::COASSIGN);
@@ -493,7 +494,7 @@ class InterviewController extends BaseController
     {
         $semester = $interview->getApplication()->getSemester();
         $department = $interview->getApplication()->getDepartment();
-        $teamUsers = $this->getDoctrine()->getRepository(User::class)
+        $teamUsers = $this->doctrine->getRepository(User::class)
             ->findUsersInDepartmentWithTeamMembershipInSemester($department, $semester);
         $coInterviewers = array_merge(array_diff($teamUsers, [$interview->getInterviewer(), $interview->getCoInterviewer()]));
         $form = $this->createForm(AddCoInterviewerType::class, null, [
@@ -505,7 +506,7 @@ class InterviewController extends BaseController
             $data = $form->getData();
             $user = $data['user'];
             $interview->setCoInterviewer($user);
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($interview);
             $em->flush();
 
@@ -528,7 +529,7 @@ class InterviewController extends BaseController
     public function clearCoInterviewer(Interview $interview): RedirectResponse
     {
         $interview->setCoInterviewer(null);
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->persist($interview);
         $em->flush();
 

--- a/src/Controller/InterviewSchemaController.php
+++ b/src/Controller/InterviewSchemaController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\InterviewSchema;
 use App\Form\Type\InterviewSchemaType;
 use App\Role\Roles;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class InterviewSchemaController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     /**
      * Shows and handles the submission of the create interview schema form.
      * Uses the same form as the edit .
@@ -37,7 +42,7 @@ class InterviewSchemaController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($schema);
             $em->flush();
 
@@ -56,7 +61,7 @@ class InterviewSchemaController extends BaseController
      */
     public function showSchemas(): Response
     {
-        $schemas = $this->getDoctrine()->getRepository(InterviewSchema::class)->findAll();
+        $schemas = $this->doctrine->getRepository(InterviewSchema::class)->findAll();
 
         return $this->render('interview/schemas.html.twig', ['schemas' => $schemas]);
     }
@@ -70,7 +75,7 @@ class InterviewSchemaController extends BaseController
         $response = [];
         try {
             if ($this->isGranted(Roles::TEAM_LEADER)) {
-                $em = $this->getDoctrine()->getManager();
+                $em = $this->doctrine->getManager();
                 $em->remove($schema);
                 $em->flush();
 

--- a/src/Controller/MailingListController.php
+++ b/src/Controller/MailingListController.php
@@ -4,12 +4,17 @@ namespace App\Controller;
 
 use App\Entity\User;
 use App\Form\Type\GenerateMailingListType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class MailingListController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(Request $request): Response
     {
         $form = $this->createForm(GenerateMailingListType::class);
@@ -47,7 +52,7 @@ class MailingListController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $users = $this->getDoctrine()->getRepository(User::class)
+        $users = $this->doctrine->getRepository(User::class)
             ->findUsersWithAssistantHistoryInDepartmentAndSemester($department, $semester);
 
         return $this->render('mailing_list/mailinglist_show.html.twig', [
@@ -59,7 +64,7 @@ class MailingListController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $users = $this->getDoctrine()->getRepository(User::class)
+        $users = $this->doctrine->getRepository(User::class)
             ->findUsersInDepartmentWithTeamMembershipInSemester($department, $semester);
 
         return $this->render('mailing_list/mailinglist_show.html.twig', [
@@ -71,9 +76,9 @@ class MailingListController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $assistantUsers = $this->getDoctrine()->getRepository(User::class)
+        $assistantUsers = $this->doctrine->getRepository(User::class)
             ->findUsersWithAssistantHistoryInDepartmentAndSemester($department, $semester);
-        $teamUsers = $this->getDoctrine()->getRepository(User::class)
+        $teamUsers = $this->doctrine->getRepository(User::class)
             ->findUsersInDepartmentWithTeamMembershipInSemester($department, $semester);
         $users = array_unique(array_merge($assistantUsers, $teamUsers));
 

--- a/src/Controller/ParticipantHistoryController.php
+++ b/src/Controller/ParticipantHistoryController.php
@@ -5,11 +5,16 @@ namespace App\Controller;
 use App\Entity\AssistantHistory;
 use App\Entity\TeamMembership;
 use App\Role\Roles;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ParticipantHistoryController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(Request $request): ?Response
     {
         $department = $this->getDepartmentOrThrow404($request);
@@ -20,10 +25,10 @@ class ParticipantHistoryController extends BaseController
         }
 
         // Find all team memberships by department
-        $teamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findTeamMembershipsByDepartment($department);
+        $teamMemberships = $this->doctrine->getRepository(TeamMembership::class)->findTeamMembershipsByDepartment($department);
 
         // Find all assistantHistories by department
-        $assistantHistories = $this->getDoctrine()->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($department, $semester);
+        $assistantHistories = $this->doctrine->getRepository(AssistantHistory::class)->findByDepartmentAndSemester($department, $semester);
 
         return $this->render('participant_history/index.html.twig', [
             'teamMemberships' => $teamMemberships,

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -23,8 +23,7 @@ class PasswordResetController extends BaseController
         private readonly PasswordManager $passwordManager,
         private readonly RequestStack $requestStack,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -7,6 +7,7 @@ use App\Form\Type\NewPasswordType;
 use App\Form\Type\PasswordResetType;
 use App\Service\LogService;
 use App\Service\PasswordManager;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -17,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class PasswordResetController extends BaseController
 {
-    public function __construct(private readonly LogService $logService, private readonly PasswordManager $passwordManager, private readonly RequestStack $requestStack)
+    public function __construct(private readonly LogService $logService, private readonly PasswordManager $passwordManager, private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -50,8 +51,8 @@ class PasswordResetController extends BaseController
                 $this->logService->notice("Password reset rejected: Someone tried to reset the password for an inactive account: $email");
             } else {
                 $this->logService->info("{$passwordReset->getUser()} requested a password reset");
-                $oldPasswordResets = $this->getDoctrine()->getRepository(PasswordReset::class)->findByUser($passwordReset->getUser());
-                $em = $this->getDoctrine()->getManager();
+                $oldPasswordResets = $this->doctrine->getRepository(PasswordReset::class)->findByUser($passwordReset->getUser());
+                $em = $this->doctrine->getManager();
 
                 foreach ($oldPasswordResets as $oldPasswordReset) {
                     $em->remove($oldPasswordReset);
@@ -98,7 +99,7 @@ class PasswordResetController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->remove($passwordReset);
             $em->persist($user);
             $em->flush();

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -18,7 +18,12 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class PasswordResetController extends BaseController
 {
-    public function __construct(private readonly LogService $logService, private readonly PasswordManager $passwordManager, private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly LogService $logService,
+        private readonly PasswordManager $passwordManager,
+        private readonly RequestStack $requestStack,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/PositionController.php
+++ b/src/Controller/PositionController.php
@@ -4,16 +4,21 @@ namespace App\Controller;
 
 use App\Entity\Position;
 use App\Form\Type\CreatePositionType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class PositionController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function showPositions(): Response
     {
         // Find all the positions
-        $positions = $this->getDoctrine()->getRepository(Position::class)->findAll();
+        $positions = $this->doctrine->getRepository(Position::class)->findAll();
 
         // Return the view with suitable variables
         return $this->render('team_admin/show_positions.html.twig', [
@@ -34,7 +39,7 @@ class PositionController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($position);
             $em->flush();
 
@@ -55,7 +60,7 @@ class PositionController extends BaseController
 
     public function removePosition(Position $position): RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($position);
         $em->flush();
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -39,8 +39,7 @@ class ProfileController extends BaseController
         private readonly TokenStorageInterface $tokenStorage,
         private readonly RequestStack $requestStack,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(): Response

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -32,7 +32,14 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ProfileController extends BaseController
 {
-    public function __construct(private readonly RoleManager $RoleManager, private readonly LogService $logService, private readonly EventDispatcherInterface $eventDispatcher, private readonly TokenStorageInterface $tokenStorage, private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly RoleManager $RoleManager,
+        private readonly LogService $logService,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly RequestStack $requestStack,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -16,6 +16,7 @@ use App\Role\Roles;
 use App\Service\LogService;
 use App\Service\RoleManager;
 use App\Service\UserRegistration;
+use Doctrine\Persistence\ManagerRegistry;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Exception;
@@ -31,7 +32,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ProfileController extends BaseController
 {
-    public function __construct(private readonly RoleManager $RoleManager, private readonly LogService $logService, private readonly EventDispatcherInterface $eventDispatcher, private readonly TokenStorageInterface $tokenStorage, private readonly RequestStack $requestStack)
+    public function __construct(private readonly RoleManager $RoleManager, private readonly LogService $logService, private readonly EventDispatcherInterface $eventDispatcher, private readonly TokenStorageInterface $tokenStorage, private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -39,7 +40,7 @@ class ProfileController extends BaseController
     {
         // Get the user currently signed in
         $user = $this->getUser();
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         // Fetch the assistant history of the user
         $assistantHistory = $em->getRepository(AssistantHistory::class)->findByUser($user);
         // Find the team history of the user
@@ -63,7 +64,7 @@ class ProfileController extends BaseController
             return $this->redirectToRoute('profile');
         }
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
 
         // Find the work history of the user
         $teamMemberships = $em->getRepository(TeamMembership::class)->findByUser($user);
@@ -93,7 +94,7 @@ class ProfileController extends BaseController
     {
         $user->setActive(false);
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->flush();
 
         return $this->redirectToRoute('specific_profile', ['id' => $user->getId()]);
@@ -103,7 +104,7 @@ class ProfileController extends BaseController
     {
         $user->setActive(true);
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->flush();
 
         return $this->redirectToRoute('specific_profile', ['id' => $user->getId()]);
@@ -127,7 +128,7 @@ class ProfileController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($user);
             $em->flush();
 
@@ -160,7 +161,7 @@ class ProfileController extends BaseController
         try {
             $user->setRoles([$roleName]);
 
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($user);
             $em->flush();
 
@@ -177,7 +178,7 @@ class ProfileController extends BaseController
 
     public function downloadCertificate(Request $request, User $user): ?RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
 
         // Fetch the assistant history of the user
         $assistantHistory = $em->getRepository(AssistantHistory::class)->findByUser($user);
@@ -186,7 +187,7 @@ class ProfileController extends BaseController
         $teamMembership = $em->getRepository(TeamMembership::class)->findByUser($user);
 
         // Find the signature of the user creating the certificate
-        $signature = $this->getDoctrine()->getRepository(Signature::class)->findByUser($this->getUser());
+        $signature = $this->doctrine->getRepository(Signature::class)->findByUser($this->getUser());
 
         // Find department
         $department = $this->getUser()->getDepartment();
@@ -237,7 +238,7 @@ class ProfileController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($user);
             $em->flush();
 
@@ -261,7 +262,7 @@ class ProfileController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($user);
             $em->flush();
 
@@ -285,7 +286,7 @@ class ProfileController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($user);
             $em->flush();
 
@@ -307,7 +308,7 @@ class ProfileController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->flush();
 
             $this->eventDispatcher->dispatch(new UserEvent($user, $oldCompanyEmail), UserEvent::COMPANY_EMAIL_EDITED);

--- a/src/Controller/ProfilePhotoController.php
+++ b/src/Controller/ProfilePhotoController.php
@@ -15,8 +15,7 @@ class ProfilePhotoController extends BaseController
     public function __construct(
         private readonly FileUploader $fileUploader,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function showEditProfilePhoto(User $user): Response

--- a/src/Controller/ProfilePhotoController.php
+++ b/src/Controller/ProfilePhotoController.php
@@ -12,7 +12,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProfilePhotoController extends BaseController
 {
-    public function __construct(private readonly FileUploader $fileUploader, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly FileUploader $fileUploader,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/ProfilePhotoController.php
+++ b/src/Controller/ProfilePhotoController.php
@@ -5,13 +5,14 @@ namespace App\Controller;
 use App\Entity\User;
 use App\Role\Roles;
 use App\Service\FileUploader;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ProfilePhotoController extends BaseController
 {
-    public function __construct(private readonly FileUploader $fileUploader)
+    public function __construct(private readonly FileUploader $fileUploader, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -42,7 +43,7 @@ class ProfilePhotoController extends BaseController
         $this->fileUploader->deleteProfileImage($user->getPicturePath());
         $user->setPicturePath($picturePath);
 
-        $this->getDoctrine()->getManager()->flush();
+        $this->doctrine->getManager()->flush();
 
         return new JsonResponse('Upload OK');
     }

--- a/src/Controller/ReceiptController.php
+++ b/src/Controller/ReceiptController.php
@@ -27,8 +27,7 @@ class ReceiptController extends BaseController
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly RoleManager $roleManager,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(): Response

--- a/src/Controller/ReceiptController.php
+++ b/src/Controller/ReceiptController.php
@@ -21,7 +21,13 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class ReceiptController extends BaseController
 {
-    public function __construct(private readonly Sorter $sorter, private readonly FileUploader $fileUploader, private readonly EventDispatcherInterface $eventDispatcher, private readonly RoleManager $roleManager, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly Sorter $sorter,
+        private readonly FileUploader $fileUploader,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly RoleManager $roleManager,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/SchoolAdminController.php
+++ b/src/Controller/SchoolAdminController.php
@@ -21,8 +21,7 @@ class SchoolAdminController extends BaseController
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function showSpecificSchool(School $school): Response

--- a/src/Controller/SchoolAdminController.php
+++ b/src/Controller/SchoolAdminController.php
@@ -18,7 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SchoolAdminController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/SchoolCapacityController.php
+++ b/src/Controller/SchoolCapacityController.php
@@ -5,12 +5,17 @@ namespace App\Controller;
 use App\Entity\SchoolCapacity;
 use App\Form\Type\SchoolCapacityEditType;
 use App\Form\Type\SchoolCapacityType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class SchoolCapacityController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function create(Request $request): RedirectResponse|Response
     {
         $department = $this->getDepartmentOrThrow404($request);
@@ -23,7 +28,7 @@ class SchoolCapacityController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($schoolCapacity);
             $em->flush();
 
@@ -42,7 +47,7 @@ class SchoolCapacityController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($capacity);
             $em->flush();
 

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -5,12 +5,17 @@ namespace App\Controller;
 use App\Entity\Application;
 use App\Role\Roles;
 use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         // get the login error if there is one
@@ -36,7 +41,7 @@ class SecurityController extends BaseController
     {
         if ($this->get('security.authorization_checker')->isGranted(Roles::TEAM_MEMBER)) {
             return $this->redirectToRoute('control_panel');
-        } elseif ($this->getDoctrine()->getRepository(Application::class)->findActiveByUser($this->getUser())) {
+        } elseif ($this->doctrine->getRepository(Application::class)->findActiveByUser($this->getUser())) {
             return $this->redirectToRoute('my_page');
         }
 

--- a/src/Controller/SemesterController.php
+++ b/src/Controller/SemesterController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Semester;
 use App\Form\Type\CreateSemesterType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,9 +12,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SemesterController extends AbstractController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(): Response
     {
-        $semesters = $this->getDoctrine()->getRepository(Semester::class)->findAllOrderedByAge();
+        $semesters = $this->doctrine->getRepository(Semester::class)->findAllOrderedByAge();
 
         return $this->render('semester_admin/index.html.twig', [
             'semesters' => $semesters,
@@ -33,7 +38,7 @@ class SemesterController extends AbstractController
         // The fields of the form is checked if they contain the correct information
         if ($form->isSubmitted() && $form->isValid()) {
             // Check if semester already exists
-            $existingSemester = $this->getDoctrine()->getManager()->getRepository(Semester::class)
+            $existingSemester = $this->doctrine->getManager()->getRepository(Semester::class)
                 ->findByTimeAndYear($semester->getSemesterTime(), $semester->getYear());
 
             // Return to semester page if semester already exists
@@ -43,7 +48,7 @@ class SemesterController extends AbstractController
                 return $this->redirectToRoute('semester_create');
             }
 
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($semester);
             $em->flush();
 
@@ -58,7 +63,7 @@ class SemesterController extends AbstractController
 
     public function delete(Semester $semester): JsonResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($semester);
         $em->flush();
 

--- a/src/Controller/SignatureController.php
+++ b/src/Controller/SignatureController.php
@@ -3,17 +3,22 @@
 namespace App\Controller;
 
 use App\Entity\Signature;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class SignatureController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function showSignatureImage($imageName): BinaryFileResponse
     {
         $user = $this->getUser();
 
-        $signature = $this->getDoctrine()->getRepository(Signature::class)->findByUser($user);
+        $signature = $this->doctrine->getRepository(Signature::class)->findByUser($user);
         if ($signature === null) {
             throw new NotFoundHttpException('Signature not found');
         }

--- a/src/Controller/SponsorsController.php
+++ b/src/Controller/SponsorsController.php
@@ -5,19 +5,20 @@ namespace App\Controller;
 use App\Entity\Sponsor;
 use App\Form\Type\SponsorType;
 use App\Service\FileUploader;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class SponsorsController extends BaseController
 {
-    public function __construct(private readonly FileUploader $fileUploader)
+    public function __construct(private readonly FileUploader $fileUploader, private readonly ManagerRegistry $doctrine)
     {
     }
 
     public function sponsorsShow(): Response
     {
-        $sponsors = $this->getDoctrine()
+        $sponsors = $this->doctrine
             ->getRepository(Sponsor::class)
             ->findAll();
 
@@ -48,7 +49,7 @@ class SponsorsController extends BaseController
                 $sponsor->setLogoImagePath($oldImgPath);
             }
 
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($sponsor);
             $em->flush();
 
@@ -73,7 +74,7 @@ class SponsorsController extends BaseController
             $this->fileUploader->deleteSponsor($sponsor->getLogoImagePath());
         }
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($sponsor);
         $em->flush();
 

--- a/src/Controller/SponsorsController.php
+++ b/src/Controller/SponsorsController.php
@@ -12,7 +12,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SponsorsController extends BaseController
 {
-    public function __construct(private readonly FileUploader $fileUploader, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly FileUploader $fileUploader,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/SponsorsController.php
+++ b/src/Controller/SponsorsController.php
@@ -15,8 +15,7 @@ class SponsorsController extends BaseController
     public function __construct(
         private readonly FileUploader $fileUploader,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function sponsorsShow(): Response

--- a/src/Controller/SsoController.php
+++ b/src/Controller/SsoController.php
@@ -4,11 +4,16 @@ namespace App\Controller;
 
 use App\Entity\User;
 use Doctrine\ORM\NoResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class SsoController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function login(Request $request): JsonResponse
     {
         $response = new JsonResponse();
@@ -24,7 +29,7 @@ class SsoController extends BaseController
         }
 
         try {
-            $user = $this->getDoctrine()->getRepository(User::class)->findByUsernameOrEmail($username);
+            $user = $this->doctrine->getRepository(User::class)->findByUsernameOrEmail($username);
         } catch (NoResultException) {
             $response->setStatusCode(401);
             $response->setContent('Username does not exist');

--- a/src/Controller/StandController.php
+++ b/src/Controller/StandController.php
@@ -13,7 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StandController extends BaseController
 {
-    public function __construct(private readonly AdmissionStatistics $AdmissionStatistics, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly AdmissionStatistics $AdmissionStatistics,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/StandController.php
+++ b/src/Controller/StandController.php
@@ -16,8 +16,7 @@ class StandController extends BaseController
     public function __construct(
         private readonly AdmissionStatistics $AdmissionStatistics,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/StandController.php
+++ b/src/Controller/StandController.php
@@ -7,12 +7,13 @@ use App\Entity\AdmissionSubscriber;
 use App\Entity\Application;
 use App\Service\AdmissionStatistics;
 use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class StandController extends BaseController
 {
-    public function __construct(private readonly AdmissionStatistics $AdmissionStatistics)
+    public function __construct(private readonly AdmissionStatistics $AdmissionStatistics, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -26,18 +27,18 @@ class StandController extends BaseController
 
         $admissionStatistics = $this->AdmissionStatistics;
 
-        $subscribers = $this->getDoctrine()->getRepository(AdmissionSubscriber::class)->findFromWebByDepartment($department);
-        $subscribersInDepartmentAndSemester = $this->getDoctrine()->getRepository(AdmissionSubscriber::class)
+        $subscribers = $this->doctrine->getRepository(AdmissionSubscriber::class)->findFromWebByDepartment($department);
+        $subscribersInDepartmentAndSemester = $this->doctrine->getRepository(AdmissionSubscriber::class)
             ->findFromWebByDepartmentAndSemester($department, $semester);
         $subData = $admissionStatistics->generateGraphDataFromSubscribersInSemester($subscribersInDepartmentAndSemester, $semester);
 
-        $applications = $this->getDoctrine()->getRepository(Application::class)->findByDepartment($department);
-        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
+        $applications = $this->doctrine->getRepository(Application::class)->findByDepartment($department);
+        $admissionPeriod = $this->doctrine->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         $applicationsInSemester = [];
         $appData = null;
         if ($admissionPeriod !== null) {
-            $applicationsInSemester = $this->getDoctrine()
+            $applicationsInSemester = $this->doctrine
                 ->getRepository(Application::class)
                 ->findByAdmissionPeriod($admissionPeriod);
             $appData = $admissionStatistics->generateGraphDataFromApplicationsInAdmissionPeriod($applicationsInSemester, $admissionPeriod);

--- a/src/Controller/SubstituteController.php
+++ b/src/Controller/SubstituteController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\AdmissionPeriod;
 use App\Entity\Application;
 use App\Form\Type\ModifySubstituteType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,6 +17,10 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
  */
 class SubstituteController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(Request $request): ?Response
     {
         // No department specified, get the user's department and call showBySemester with
@@ -23,12 +28,12 @@ class SubstituteController extends BaseController
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
 
-        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
+        $admissionPeriod = $this->doctrine->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
 
         $substitutes = null;
         if ($admissionPeriod !== null) {
-            $substitutes = $this->getDoctrine()
+            $substitutes = $this->doctrine
                 ->getRepository(Application::class)
                 ->findSubstitutesByAdmissionPeriod($admissionPeriod);
         }
@@ -56,7 +61,7 @@ class SubstituteController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($application);
             $em->flush();
 
@@ -78,7 +83,7 @@ class SubstituteController extends BaseController
     {
         $application->setSubstitute(false);
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->persist($application);
         $em->flush();
 
@@ -97,7 +102,7 @@ class SubstituteController extends BaseController
         }
         $application->setSubstitute(true);
 
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->persist($application);
         $em->flush();
 

--- a/src/Controller/TeamAdminController.php
+++ b/src/Controller/TeamAdminController.php
@@ -21,8 +21,7 @@ class TeamAdminController extends BaseController
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function show(Department $department = null): Response

--- a/src/Controller/TeamAdminController.php
+++ b/src/Controller/TeamAdminController.php
@@ -10,6 +10,7 @@ use App\Event\TeamEvent;
 use App\Event\TeamMembershipEvent;
 use App\Form\Type\CreateTeamMembershipType;
 use App\Form\Type\CreateTeamType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TeamAdminController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher)
+    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -28,8 +29,8 @@ class TeamAdminController extends BaseController
         }
 
         // Find teams that are connected to the department of the user
-        $activeTeams = $this->getDoctrine()->getRepository(Team::class)->findActiveByDepartment($department);
-        $inactiveTeams = $this->getDoctrine()->getRepository(Team::class)->findInactiveByDepartment($department);
+        $activeTeams = $this->doctrine->getRepository(Team::class)->findActiveByDepartment($department);
+        $inactiveTeams = $this->doctrine->getRepository(Team::class)->findInactiveByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('team_admin/index.html.twig', [
@@ -50,7 +51,7 @@ class TeamAdminController extends BaseController
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $teamMembership->setIsSuspended(false);
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($teamMembership);
             $em->flush();
 
@@ -74,7 +75,7 @@ class TeamAdminController extends BaseController
         // Create a new TeamMembership entity
         $teamMembership = new TeamMembership();
         $teamMembership->setUser($this->getUser());
-        $teamMembership->setPosition($this->getDoctrine()->getRepository(Position::class)->findOneBy(['name' => 'Medlem']));
+        $teamMembership->setPosition($this->doctrine->getRepository(Position::class)->findOneBy(['name' => 'Medlem']));
 
         // Create a new formType with the needed variables
         $form = $this->createForm(CreateTeamMembershipType::class, $teamMembership, [
@@ -89,7 +90,7 @@ class TeamAdminController extends BaseController
             $teamMembership->setTeam($team);
 
             // Persist the team to the database
-            $em = $this->getDoctrine()->getManager();
+            $em = $this->doctrine->getManager();
             $em->persist($teamMembership);
             $em->flush();
 
@@ -107,13 +108,13 @@ class TeamAdminController extends BaseController
     public function showSpecificTeam(Team $team): Response
     {
         // Find all TeamMembership entities based on team
-        $activeTeamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeam($team);
-        $inActiveTeamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findInactiveTeamMembershipsByTeam($team);
+        $activeTeamMemberships = $this->doctrine->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeam($team);
+        $inActiveTeamMemberships = $this->doctrine->getRepository(TeamMembership::class)->findInactiveTeamMembershipsByTeam($team);
         usort($activeTeamMemberships, $this->sortTeamMembershipsByEndDate(...));
         usort($inActiveTeamMemberships, $this->sortTeamMembershipsByEndDate(...));
 
         $user = $this->getUser();
-        $currentUserTeamMembership = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByUser($user);
+        $currentUserTeamMembership = $this->doctrine->getRepository(TeamMembership::class)->findActiveTeamMembershipsByUser($user);
         $isUserInTeam = false;
         foreach ($currentUserTeamMembership as $wh) {
             if (in_array($wh, $activeTeamMemberships, true)) {
@@ -151,7 +152,7 @@ class TeamAdminController extends BaseController
             // Don't persist if the preview button was clicked
             if (!$form->get('preview')->isClicked()) {
                 // Persist the team to the database
-                $em = $this->getDoctrine()->getManager();
+                $em = $this->doctrine->getManager();
                 $em->persist($team);
                 $em->flush();
 
@@ -159,7 +160,7 @@ class TeamAdminController extends BaseController
 
                 return $this->redirect($this->generateUrl('teamadmin_show'));
             }
-            $teamMemberships = $this->getDoctrine()->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeam($team);
+            $teamMemberships = $this->doctrine->getRepository(TeamMembership::class)->findActiveTeamMembershipsByTeam($team);
 
             // Render the teampage as a preview
             return $this->render('team/team_page.html.twig', [
@@ -179,7 +180,7 @@ class TeamAdminController extends BaseController
     public function showTeamsByDepartment(Department $department): Response
     {
         // Find teams that are connected to the department of the department ID sent in by the request
-        $teams = $this->getDoctrine()->getRepository(Team::class)->findByDepartment($department);
+        $teams = $this->doctrine->getRepository(Team::class)->findByDepartment($department);
 
         // Return the view with suitable variables
         return $this->render('team_admin/index.html.twig', [
@@ -207,7 +208,7 @@ class TeamAdminController extends BaseController
             // Don't persist if the preview button was clicked
             if (!$form->get('preview')->isClicked()) {
                 // Persist the team to the database
-                $em = $this->getDoctrine()->getManager();
+                $em = $this->doctrine->getManager();
                 $em->persist($team);
                 $em->flush();
 
@@ -233,7 +234,7 @@ class TeamAdminController extends BaseController
 
     public function removeUserFromTeamById(TeamMembership $teamMembership): RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
         $em->remove($teamMembership);
         $em->flush();
 
@@ -244,7 +245,7 @@ class TeamAdminController extends BaseController
 
     public function deleteTeamById(Team $team): RedirectResponse
     {
-        $em = $this->getDoctrine()->getManager();
+        $em = $this->doctrine->getManager();
 
         foreach ($team->getTeamMemberships() as $teamMembership) {
             $teamMembership->setDeletedTeamName($team->getName());

--- a/src/Controller/TeamAdminController.php
+++ b/src/Controller/TeamAdminController.php
@@ -18,7 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TeamAdminController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/TeamApplicationController.php
+++ b/src/Controller/TeamApplicationController.php
@@ -21,8 +21,7 @@ class TeamApplicationController extends BaseController
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function showApplication(TeamApplication $application): Response

--- a/src/Controller/TeamApplicationController.php
+++ b/src/Controller/TeamApplicationController.php
@@ -18,7 +18,10 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class TeamApplicationController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -4,11 +4,16 @@ namespace App\Controller;
 
 use App\Entity\Team;
 use App\Role\Roles;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class TeamController extends BaseController
 {
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
     public function show(Team $team): Response
     {
         if (!$team->isActive() && !$this->isGranted(Roles::TEAM_MEMBER)) {
@@ -22,7 +27,7 @@ class TeamController extends BaseController
 
     public function showByDepartmentAndTeam($departmentCity, $teamName): Response
     {
-        $teams = $this->getDoctrine()->getRepository(Team::class)->findByCityAndName($departmentCity, $teamName);
+        $teams = $this->doctrine->getRepository(Team::class)->findByCityAndName($departmentCity, $teamName);
         if ((is_countable($teams) ? count($teams) : 0) !== 1) {
             throw new NotFoundHttpException('Team not found');
         }

--- a/src/Controller/TeamInterestController.php
+++ b/src/Controller/TeamInterestController.php
@@ -18,8 +18,7 @@ class TeamInterestController extends BaseController
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Controller/TeamInterestController.php
+++ b/src/Controller/TeamInterestController.php
@@ -15,7 +15,10 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class TeamInterestController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/TeamInterestController.php
+++ b/src/Controller/TeamInterestController.php
@@ -6,6 +6,7 @@ use App\Entity\Department;
 use App\Entity\TeamInterest;
 use App\Event\TeamInterestCreatedEvent;
 use App\Form\Type\TeamInterestType;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,7 +15,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class TeamInterestController extends BaseController
 {
-    public function __construct(private readonly EventDispatcherInterface $eventDispatcher)
+    public function __construct(private readonly EventDispatcherInterface $eventDispatcher, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -37,7 +38,7 @@ class TeamInterestController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $manager = $this->getDoctrine()->getManager();
+            $manager = $this->doctrine->getManager();
             $manager->persist($teamInterest);
             $manager->flush();
 

--- a/src/Controller/UserAdminController.php
+++ b/src/Controller/UserAdminController.php
@@ -16,8 +16,7 @@ class UserAdminController extends BaseController
     public function __construct(
         private readonly UserRegistration $userRegistration,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function createUser(Request $request, Department $department = null)

--- a/src/Controller/UserAdminController.php
+++ b/src/Controller/UserAdminController.php
@@ -13,7 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UserAdminController extends BaseController
 {
-    public function __construct(private readonly UserRegistration $userRegistration, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly UserRegistration $userRegistration,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -14,8 +14,7 @@ class UserController extends BaseController
     public function __construct(
         private readonly ApplicationManager $applicationManager,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function myPage(): Response

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -11,7 +11,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UserController extends BaseController
 {
-    public function __construct(private readonly ApplicationManager $applicationManager, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly ApplicationManager $applicationManager,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/WidgetController.php
+++ b/src/Controller/WidgetController.php
@@ -17,7 +17,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class WidgetController extends BaseController
 {
-    public function __construct(private readonly Sorter $sorter, private readonly AdmissionStatistics $admissionStatistics, private readonly ManagerRegistry $doctrine)
+    public function __construct(
+        private readonly Sorter $sorter,
+        private readonly AdmissionStatistics $admissionStatistics,
+        private readonly ManagerRegistry $doctrine
+    )
     {
     }
 

--- a/src/Controller/WidgetController.php
+++ b/src/Controller/WidgetController.php
@@ -11,12 +11,13 @@ use App\Entity\User;
 use App\Service\AdmissionStatistics;
 use App\Service\Sorter;
 use App\Utils\ReceiptStatistics;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class WidgetController extends BaseController
 {
-    public function __construct(private readonly Sorter $sorter, private readonly AdmissionStatistics $admissionStatistics)
+    public function __construct(private readonly Sorter $sorter, private readonly AdmissionStatistics $admissionStatistics, private readonly ManagerRegistry $doctrine)
     {
     }
 
@@ -24,12 +25,12 @@ class WidgetController extends BaseController
     {
         $department = $this->getDepartmentOrThrow404($request);
         $semester = $this->getSemesterOrThrow404($request);
-        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
+        $admissionPeriod = $this->doctrine->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         $applicationsAssignedToUser = [];
 
         if ($admissionPeriod !== null) {
-            $applicationRepo = $this->getDoctrine()->getRepository(Application::class);
+            $applicationRepo = $this->doctrine->getRepository(Application::class);
             $applicationsAssignedToUser = $applicationRepo->findAssignedByUserAndAdmissionPeriod($this->getUser(), $admissionPeriod);
         }
 
@@ -38,13 +39,13 @@ class WidgetController extends BaseController
 
     public function receipts(): Response
     {
-        $usersWithReceipts = $this->getDoctrine()->getRepository(User::class)->findAllUsersWithReceipts();
+        $usersWithReceipts = $this->doctrine->getRepository(User::class)->findAllUsersWithReceipts();
         $sorter = $this->sorter;
 
         $sorter->sortUsersByReceiptSubmitTime($usersWithReceipts);
         $sorter->sortUsersByReceiptStatus($usersWithReceipts);
 
-        $pendingReceipts = $this->getDoctrine()->getRepository(Receipt::class)->findByStatus(Receipt::STATUS_PENDING);
+        $pendingReceipts = $this->doctrine->getRepository(Receipt::class)->findByStatus(Receipt::STATUS_PENDING);
         $pendingReceiptStatistics = new ReceiptStatistics($pendingReceipts);
 
         $hasReceipts = !empty($pendingReceipts);
@@ -68,11 +69,11 @@ class WidgetController extends BaseController
 
         $admissionStatistics = $this->admissionStatistics;
 
-        $admissionPeriod = $this->getDoctrine()->getRepository(AdmissionPeriod::class)
+        $admissionPeriod = $this->doctrine->getRepository(AdmissionPeriod::class)
             ->findOneByDepartmentAndSemester($department, $semester);
         $applicationsInSemester = [];
         if ($admissionPeriod !== null) {
-            $applicationsInSemester = $this->getDoctrine()
+            $applicationsInSemester = $this->doctrine
                 ->getRepository(Application::class)
                 ->findByAdmissionPeriod($admissionPeriod);
             $appData = $admissionStatistics->generateCumulativeGraphDataFromApplicationsInAdmissionPeriod($applicationsInSemester, $admissionPeriod);

--- a/src/Controller/WidgetController.php
+++ b/src/Controller/WidgetController.php
@@ -21,8 +21,7 @@ class WidgetController extends BaseController
         private readonly Sorter $sorter,
         private readonly AdmissionStatistics $admissionStatistics,
         private readonly ManagerRegistry $doctrine
-    )
-    {
+    ) {
     }
 
     public function interviews(Request $request): ?Response


### PR DESCRIPTION
### Describe your changes 📖
`getDoctrine` is deprecated. 
Replaced with use of `ManagerRegistry` using dp-injection.

Remaining getDoctrine depr. after this PR:
- BaseController.

**Before**
Remaining direct deprecation notices (768)

**After**
Remaining direct deprecation notices (223)

### Linear ticket: 🔖
VB-XXX

### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Sonarcloud scan passes
- [x] Linter job passes
- [x] Unit tests passes
