### PR TITLE
Set CKEditor4 version to latest non-lts (4.22.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
             "elfinder:install": "symfony-cmd"
         },
         "post-install-cmd": [
-            "php bin/console ckeditor:install",
+            "php bin/console ckeditor:install --tag=4.22.1",
             "php bin/console assets:install public"
         ],
         "post-update-cmd": [


### PR DESCRIPTION
### Describe your changes 📖
Specifies the CKEditor4 version to be the latest version not needing lts-key.

### Linear ticket: 🔖
VB-204

### Checklist before requesting a review ✔️
- [x] I have performed a self-review of my code
- [x] Sonarcloud scan passes
- [ ] Linter job passes
- [x] Unit tests passes
