### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			// Install Intellephense PHP language server.
+			"extensions": [
+				"bmewburn.vscode-intelephense-client"
+			]
+		}
+	}
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}


### PR DESCRIPTION
### Describe your changes 📖
Add devcontainer, that uses the Dockerfile.
This can be used for local development in vscode or phpstorm, but also online on github codespaces on e.g. code review.

### Linear ticket: 🔖
VB-XXX

### Checklist before requesting a review ✔️
- [ ] I have performed a self-review of my code
- [ ] Sonarcloud scan passes
- [ ] Linter job passes
- [ ] Unit tests passes
